### PR TITLE
fix: prevent Gallica discovery freeze on repeated searches

### DIFF
--- a/src/studio_ui/components/discovery.py
+++ b/src/studio_ui/components/discovery.py
@@ -53,12 +53,16 @@ def render_search_results_list(results: list) -> Div:
         hx_vals = json.dumps({"manifest_url": manifest_url, "doc_id": doc_id, "library": library}, ensure_ascii=True)
         badge_id = f"pdf-badge-{(doc_id or 'item').replace(' ', '-').replace('/', '-')[:28]}"
         pdf_badge = Div(
-            "PDF: verifica...",
-            id=badge_id,
-            hx_get=f"/api/discovery/pdf_capability?manifest_url={quote(manifest_url, safe='')}",
-            hx_trigger="load",
-            hx_swap="outerHTML",
-            cls="app-chip app-chip-neutral text-[11px] tracking-wide",
+            Div("PDF: n/d", id=badge_id, cls="app-chip app-chip-neutral text-[11px] tracking-wide"),
+            Button(
+                "Verifica PDF",
+                type="button",
+                hx_get=f"/api/discovery/pdf_capability?manifest_url={quote(manifest_url, safe='')}",
+                hx_target=f"#{badge_id}",
+                hx_swap="outerHTML",
+                cls="app-btn app-btn-neutral text-[11px] px-2 py-1",
+            ),
+            cls="flex items-center gap-1.5",
         )
 
         meta_line = []
@@ -412,12 +416,20 @@ def render_preview(data: dict) -> Div:
     else:
         meta_items.append(
             Div(
-                "PDF: verifica...",
-                id="preview-pdf-badge",
-                hx_get=f"/api/discovery/pdf_capability?manifest_url={quote(str(manifest_url or ''), safe='')}",
-                hx_trigger="load",
-                hx_swap="outerHTML",
-                cls="text-xs bg-slate-700 text-slate-300 px-2 py-1 rounded",
+                Div(
+                    "PDF: n/d",
+                    id="preview-pdf-badge",
+                    cls="text-xs bg-slate-700 text-slate-300 px-2 py-1 rounded",
+                ),
+                Button(
+                    "Verifica PDF",
+                    type="button",
+                    hx_get=f"/api/discovery/pdf_capability?manifest_url={quote(str(manifest_url or ''), safe='')}",
+                    hx_target="#preview-pdf-badge",
+                    hx_swap="outerHTML",
+                    cls="app-btn app-btn-neutral text-[11px] px-2 py-1",
+                ),
+                cls="inline-flex items-center gap-1.5",
             )
         )
 

--- a/tests/test_discovery_download_manager.py
+++ b/tests/test_discovery_download_manager.py
@@ -24,9 +24,9 @@ def test_add_to_library_persists_saved_entry(monkeypatch):
     assert int(ms.get("total_canvases") or 0) == 12
 
 
-def test_pdf_capability_badge_uses_manifest_analysis(monkeypatch):
-    """PDF capability endpoint must render positive badge when manifest exposes PDF."""
-    monkeypatch.setattr(discovery_handlers, "analyze_manifest", lambda _url: {"has_native_pdf": True})
+def test_pdf_capability_badge_uses_quick_probe(monkeypatch):
+    """PDF capability endpoint should use lightweight probe path."""
+    monkeypatch.setattr(discovery_handlers, "_quick_manifest_has_native_pdf", lambda _url: True)
     frag = discovery_handlers.pdf_capability("https://example.org/manifest.json")
     assert "PDF nativo disponibile" in repr(frag)
 

--- a/tests/test_discovery_handlers_resolve_manifest.py
+++ b/tests/test_discovery_handlers_resolve_manifest.py
@@ -45,6 +45,9 @@ def test_resolve_manifest_gallica_search_results_list(monkeypatch):
     result = discovery_handlers.resolve_manifest("Gallica", "dante")
     result_str = repr(result)
     assert "Trovati 2 risultati" in result_str
+    assert "Verifica PDF" in result_str
+    assert "/api/discovery/pdf_capability?manifest_url=" in result_str
+    assert 'hx_trigger="load"' not in result_str
 
 
 def test_resolve_manifest_gallica_passes_optional_filter(monkeypatch):


### PR DESCRIPTION
Summary:
- remove automatic PDF capability preloads on Discovery results/preview (hx_trigger load)
- make PDF capability check explicit and on-demand via Verifica PDF button
- replace heavy manifest analysis in /api/discovery/pdf_capability with a lightweight rendering probe
- add short in-memory cache for PDF capability responses

Why:
Repeated Gallica searches could stall because each result card fired extra background requests to check PDF capability, saturating request handling and delaying subsequent searches.

Validation:
- ruff check on modified files
- pytest tests/test_discovery_download_manager.py tests/test_discovery_handlers_resolve_manifest.py -q