### PR TITLE
fix(core): replace print() with logger in core modules

### DIFF
--- a/src/universal_iiif_core/logger.py
+++ b/src/universal_iiif_core/logger.py
@@ -76,7 +76,9 @@ def setup_logging():
         file_handler.setLevel(effective_level)  # Ensure handler level is set
         app_logger.addHandler(file_handler)
     except Exception as e:
-        print(f"FAILED TO SETUP FILE LOGGING: {e}")
+        sys.stderr.write(f"FAILED TO SETUP FILE LOGGING: {e}\n")
+        # Fallback: at least console handler should work
+        app_logger.error(f"Failed to setup file logging: {e}", exc_info=True)
 
     app_logger.info("Localized logging system initialized (Level: %s) -> %s", log_level, log_file)
 

--- a/src/universal_iiif_core/logic/downloader.py
+++ b/src/universal_iiif_core/logic/downloader.py
@@ -580,7 +580,7 @@ class IIIFDownloader:
 
         try:
             self.logger.info(f"Generating PDF for {len(files)} pages...")
-            print("Creating Professional PDF with Cover & Colophon...")
+            self.logger.info("Creating Professional PDF with Cover & Colophon...")
 
             with tqdm(total=len(files), desc="Generating PDF", unit="page") as pbar:
 
@@ -604,7 +604,7 @@ class IIIFDownloader:
                 )
 
             self.logger.info(f"PDF Generated successfully: {output_path}")
-            print(f"✅ PDF Created: {output_path}")
+            self.logger.info(f"✅ PDF Created: {output_path}")
         except Exception as e:
             self.logger.error(f"Failed to generate professional PDF: {e}", exc_info=True)
             # Fallback to simple image append if needed, but let's trust the new system

--- a/src/universal_iiif_core/services/storage/vault_manager.py
+++ b/src/universal_iiif_core/services/storage/vault_manager.py
@@ -715,7 +715,7 @@ class VaultManager:
                 # Convert to PNG bytes
                 return pix.tobytes("png")
         except Exception as e:
-            print(f"Error extracting snippet with fitz: {e}")
+            logger.error(f"Error extracting snippet with fitz: {e}", exc_info=True)
             return None
 
     def save_snippet(


### PR DESCRIPTION
## 🎯 Obiettivo

Risolvere l'issue #59: sostituire tutti i `print()` nei moduli core con chiamate logger appropriate per garantire che l'output sia catturato nei build .exe su Windows.

## 🔧 Modifiche

### File modificati (3):
1. **src/universal_iiif_core/logger.py** (linea 79)
   - Sostituito `print()` con `sys.stderr.write()` + `app_logger.error()` con stack trace
   - Razionale: Il logger stesso sta fallendo, necessario fallback a stderr

2. **src/universal_iiif_core/logic/downloader.py** (linee 583, 607)
   - Sostituiti 2 `print()` con `self.logger.info()` per messaggi progresso PDF
   - Messaggi: "Creating Professional PDF..." e "✅ PDF Created"

3. **src/universal_iiif_core/services/storage/vault_manager.py** (linea 718)
   - Sostituito `print()` con `logger.error()` + `exc_info=True`
   - Gestione errori estrazione snippet con stack trace completo

## ✅ Verifiche Completate

- ✅ **Grep audit**: Zero `print()` in `src/universal_iiif_core/` e `src/studio_ui/`
- ✅ **CLI intatto**: 33 `print()` rimangono in `src/universal_iiif_cli/` (corretto - interazione utente)
- ✅ **Linting**: Ruff check passa senza errori
- ✅ **Test**: Tutti i 159 test passano (5 skipped)

## 📋 Criteri di Accettazione (Issue #59)

- [x] Zero `print()` in `src/universal_iiif_core/**/*.py`
- [x] Zero `print()` in `src/studio_ui/**/*.py`
- [x] `print()` permessi solo in `src/universal_iiif_cli/**/*.py`
- [x] Log file contiene tutte le operazioni critiche
- [x] Test: suite completa passa

## 💡 Impatto

**Nessun cambiamento visibile per utenti web:**
- I log continuano su console (stdout) + file (logs/app.log)
- Comportamento identico per l'applicazione web

**Beneficio per .exe Windows:**
- Tutti i messaggi ora catturati nei file di log
- Debug possibile dopo crash
- Supporto utenti desktop finalmente affidabile

## 🔗 Collegamenti

- Fixes #59