### PR TITLE
chore: add global config validation diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ All notable changes to this project are documented in this file.
 - Every non-empty bullet should reference an issue or PR number using the `(#123)` suffix.
 - If a section has no items, use `- None.`
 
+## [v0.6.1] - 2026-03-02
+
+### Added
+
+- Added global, non-mutating `config.json` validation with severity-based diagnostics (`WARNING`/`ERROR`) during `ConfigManager.load()` (#73).
+- Added dedicated tests for config schema/deprecation validation and load-time logging behavior (#73).
+
+### Changed
+
+- Deprecated thumbnail keys are now explicitly reported as runtime warnings instead of being silently ignored (#73).
+- Validation logs avoid leaking sensitive config values such as API keys and tokens (#73).
+
+### Fixed
+
+- Improved startup diagnostics for malformed configuration roots and invalid JSON payloads (`ERROR` severity where appropriate) (#73).
+
 ## [v0.6.0] - 2026-01-23
 
 ### Added

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -10,6 +10,27 @@ This reference documents the full `config.json` keyspace currently used by the a
 
 If a key appears in one source but not the other, keep this document aligned with runtime behavior in `ConfigManager`.
 
+## Runtime Validation Policy
+
+At startup, `ConfigManager.load()` runs a non-mutating validation pass over the merged `config.json`:
+- `ERROR`: invalid critical structures/types (for example malformed `paths` or `security.allowed_origins`).
+- `WARNING`: deprecated keys, unknown keys, and non-fatal semantic anomalies (enum/range/reference issues).
+
+Validation only logs diagnostics; it does **not** rewrite `config.json`.
+Sensitive values (for example API keys/tokens) are never emitted in clear text by validation logs.
+
+Deprecated keys currently flagged:
+- `settings.thumbnails.columns`
+- `settings.thumbnails.paginate_enabled`
+- `settings.thumbnails.default_select_all`
+- `settings.thumbnails.actions_apply_to_all_default`
+- `settings.thumbnails.hover_preview_enabled`
+- `settings.thumbnails.hover_preview_max_long_edge_px`
+- `settings.thumbnails.hover_preview_jpeg_quality`
+- `settings.thumbnails.hover_preview_delay_ms`
+- `settings.thumbnails.inline_base64_max_tiles`
+- `settings.thumbnails.hover_preview_max_tiles`
+
 ## Top-Level Schema
 
 ```text

--- a/src/universal_iiif_core/config_manager.py
+++ b/src/universal_iiif_core/config_manager.py
@@ -16,6 +16,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from .config_validation import SEVERITY_ERROR, validate_config
 from .logger import get_logger
 
 logger = get_logger(__name__)
@@ -225,6 +226,28 @@ def _deep_merge(dst: dict[str, Any], src: dict[str, Any]) -> dict[str, Any]:
     return dst
 
 
+def _log_validation_report(data: dict[str, Any]) -> None:
+    issues = validate_config(data, schema=DEFAULT_CONFIG_JSON)
+    if not issues:
+        return
+
+    error_count = 0
+    warning_count = 0
+    for issue in issues:
+        if issue.severity == SEVERITY_ERROR:
+            error_count += 1
+            logger.error("Config validation [%s] at '%s': %s", issue.code, issue.path, issue.message)
+        else:
+            warning_count += 1
+            logger.warning("Config validation [%s] at '%s': %s", issue.code, issue.path, issue.message)
+
+    logger.info(
+        "Config validation completed: %s error(s), %s warning(s).",
+        error_count,
+        warning_count,
+    )
+
+
 def _try_make_parent_writable(path: Path) -> bool:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -269,8 +292,13 @@ class ConfigManager:
                 loaded = json.loads(cfg_path.read_text(encoding="utf-8") or "{}")
                 if isinstance(loaded, dict):
                     _deep_merge(data, loaded)
+                else:
+                    logger.error("Invalid config root at %s: expected object, got %s", cfg_path, type(loaded).__name__)
             except (OSError, json.JSONDecodeError) as exc:
-                logger.warning("Failed to read config.json at %s: %s", cfg_path, exc)
+                if isinstance(exc, json.JSONDecodeError):
+                    logger.error("Failed to parse config.json at %s: %s", cfg_path, exc)
+                else:
+                    logger.warning("Failed to read config.json at %s: %s", cfg_path, exc)
         else:
             # Ensure file exists for user edits
             try:
@@ -289,6 +317,8 @@ class ConfigManager:
                 # Keep the in-memory config clean; it will disappear on next save.
                 with suppress(KeyError):
                     del pdf_cfg["render_dpi"]
+
+        _log_validation_report(data)
 
         return cls(path=cfg_path, _data=data)
 

--- a/src/universal_iiif_core/config_validation.py
+++ b/src/universal_iiif_core/config_validation.py
@@ -1,0 +1,533 @@
+"""Runtime validation for config.json.
+
+The validator is non-mutating by design: it reports anomalies as issues
+without rewriting user configuration files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+SEVERITY_WARNING = "WARNING"
+SEVERITY_ERROR = "ERROR"
+
+
+@dataclass(frozen=True)
+class ConfigValidationIssue:
+    """One validation diagnostic produced by the config validator."""
+
+    severity: str
+    path: str
+    code: str
+    message: str
+
+
+DEPRECATED_KEYS: tuple[str, ...] = (
+    "settings.thumbnails.columns",
+    "settings.thumbnails.paginate_enabled",
+    "settings.thumbnails.default_select_all",
+    "settings.thumbnails.actions_apply_to_all_default",
+    "settings.thumbnails.hover_preview_enabled",
+    "settings.thumbnails.hover_preview_max_long_edge_px",
+    "settings.thumbnails.hover_preview_jpeg_quality",
+    "settings.thumbnails.hover_preview_delay_ms",
+    "settings.thumbnails.inline_base64_max_tiles",
+    "settings.thumbnails.hover_preview_max_tiles",
+)
+
+
+PROFILE_PAYLOAD_SCHEMA: dict[str, Any] = {
+    "label": "Balanced",
+    "compression": "Standard",
+    "include_cover": True,
+    "include_colophon": True,
+    "image_source_mode": "local_balanced",
+    "image_max_long_edge_px": 2600,
+    "jpeg_quality": 82,
+    "force_remote_refetch": False,
+    "cleanup_temp_after_export": True,
+    "max_parallel_page_fetch": 2,
+}
+
+_CRITICAL_PREFIXES = ("paths", "security", "api_keys")
+_FLOAT_COMPATIBLE_PATHS = {
+    "settings.images.tile_stitch_max_ram_gb",
+    "settings.viewer.mirador.openSeadragonOptions.maxZoomPixelRatio",
+    "settings.viewer.mirador.openSeadragonOptions.maxZoomLevel",
+    "settings.viewer.mirador.openSeadragonOptions.minZoomLevel",
+    "settings.viewer.visual_filters.defaults.brightness",
+    "settings.viewer.visual_filters.defaults.contrast",
+    "settings.viewer.visual_filters.defaults.saturation",
+    "settings.viewer.visual_filters.defaults.hue",
+    "settings.viewer.visual_filters.presets.default.brightness",
+    "settings.viewer.visual_filters.presets.default.contrast",
+    "settings.viewer.visual_filters.presets.default.saturation",
+    "settings.viewer.visual_filters.presets.default.hue",
+    "settings.viewer.visual_filters.presets.night.brightness",
+    "settings.viewer.visual_filters.presets.night.contrast",
+    "settings.viewer.visual_filters.presets.night.saturation",
+    "settings.viewer.visual_filters.presets.night.hue",
+    "settings.viewer.visual_filters.presets.contrast.brightness",
+    "settings.viewer.visual_filters.presets.contrast.contrast",
+    "settings.viewer.visual_filters.presets.contrast.saturation",
+    "settings.viewer.visual_filters.presets.contrast.hue",
+}
+
+
+def validate_config(data: dict[str, Any], schema: dict[str, Any]) -> list[ConfigValidationIssue]:
+    """Validate merged config data against schema and runtime expectations."""
+    issues: list[ConfigValidationIssue] = []
+    _validate_structure(data, schema, path="", issues=issues)
+    _validate_deprecated_keys(data, issues)
+    _validate_semantics(data, issues)
+    return issues
+
+
+def _validate_structure(
+    node: Any,
+    schema: Any,
+    *,
+    path: str,
+    issues: list[ConfigValidationIssue],
+) -> None:
+    if path == "settings.pdf.profiles.catalog":
+        _validate_profiles_catalog(node, path=path, issues=issues)
+        return
+
+    if path == "settings.pdf.profiles.document_overrides":
+        if not isinstance(node, dict):
+            _add_error(
+                issues,
+                path=path,
+                code="invalid_type",
+                message=f"Expected object, got {_type_name(node)}.",
+            )
+        return
+
+    if isinstance(schema, dict):
+        _validate_object_structure(node, schema, path=path, issues=issues)
+        return
+
+    if isinstance(schema, list):
+        _validate_array_structure(node, schema, path=path, issues=issues)
+        return
+
+    _validate_scalar_structure(node, schema, path=path, issues=issues)
+
+
+def _validate_object_structure(
+    node: Any,
+    schema: dict[str, Any],
+    *,
+    path: str,
+    issues: list[ConfigValidationIssue],
+) -> None:
+    if not isinstance(node, dict):
+        _add_type_issue(issues, path=path or "$", expected="object", value=node)
+        return
+    for key in node:
+        if key not in schema:
+            _add_warning(
+                issues,
+                path=_join(path, key),
+                code="unknown_key",
+                message="Unknown config key.",
+            )
+    for key, child_schema in schema.items():
+        if key in node:
+            _validate_structure(node[key], child_schema, path=_join(path, key), issues=issues)
+
+
+def _validate_array_structure(
+    node: Any,
+    schema: list[Any],
+    *,
+    path: str,
+    issues: list[ConfigValidationIssue],
+) -> None:
+    if not isinstance(node, list):
+        _add_type_issue(issues, path=path, expected="array", value=node)
+        return
+    if not schema:
+        return
+    sample = schema[0]
+    for idx, item in enumerate(node):
+        _validate_structure(item, sample, path=f"{path}[{idx}]", issues=issues)
+
+
+def _validate_scalar_structure(
+    node: Any,
+    schema: Any,
+    *,
+    path: str,
+    issues: list[ConfigValidationIssue],
+) -> None:
+    expected_type = type(schema)
+    if (
+        expected_type is int
+        and path in _FLOAT_COMPATIBLE_PATHS
+        and isinstance(node, (int, float))
+        and not isinstance(node, bool)
+    ):
+        return
+    if _matches_type(node, expected_type):
+        return
+    _add_type_issue(issues, path=path, expected=expected_type.__name__, value=node)
+
+
+def _validate_profiles_catalog(
+    node: Any,
+    *,
+    path: str,
+    issues: list[ConfigValidationIssue],
+) -> None:
+    if not isinstance(node, dict):
+        _add_error(
+            issues,
+            path=path,
+            code="invalid_type",
+            message=f"Expected object, got {_type_name(node)}.",
+        )
+        return
+
+    for profile_name, payload in node.items():
+        profile_path = _join(path, str(profile_name))
+        if not isinstance(payload, dict):
+            _add_error(
+                issues,
+                path=profile_path,
+                code="invalid_type",
+                message=f"Expected object, got {_type_name(payload)}.",
+            )
+            continue
+        for key in payload:
+            if key not in PROFILE_PAYLOAD_SCHEMA:
+                _add_warning(
+                    issues,
+                    path=_join(profile_path, key),
+                    code="unknown_key",
+                    message="Unknown profile field.",
+                )
+        for key, expected in PROFILE_PAYLOAD_SCHEMA.items():
+            if key not in payload:
+                continue
+            if not _matches_type(payload[key], type(expected)):
+                _add_error(
+                    issues,
+                    path=_join(profile_path, key),
+                    code="invalid_type",
+                    message=f"Expected {type(expected).__name__}, got {_type_name(payload[key])}.",
+                )
+
+
+def _validate_deprecated_keys(data: dict[str, Any], issues: list[ConfigValidationIssue]) -> None:
+    for key_path in DEPRECATED_KEYS:
+        if _path_exists(data, key_path):
+            _add_warning(
+                issues,
+                path=key_path,
+                code="deprecated_key",
+                message="Deprecated config key is present and ignored by current runtime.",
+            )
+
+
+def _validate_semantics(data: dict[str, Any], issues: list[ConfigValidationIssue]) -> None:
+    _validate_allowed_origins(data, issues)
+    _validate_int_range(data, issues, "settings.system.max_concurrent_downloads", 1, 16)
+    _validate_int_range(data, issues, "settings.ui.items_per_page", 1, 200)
+    _validate_int_range(data, issues, "settings.ui.toast_duration", 500, 15000)
+    _validate_int_range(data, issues, "settings.images.viewer_quality", 10, 100)
+    _validate_float_range(data, issues, "settings.images.tile_stitch_max_ram_gb", 0.1, 64.0)
+    _validate_int_range(data, issues, "settings.thumbnails.page_size", 1, 120)
+    _validate_int_range(data, issues, "settings.thumbnails.max_long_edge_px", 64, 2000)
+    _validate_int_range(data, issues, "settings.thumbnails.jpeg_quality", 10, 100)
+    _validate_int_range(data, issues, "settings.storage.exports_retention_days", 1, 3650)
+    _validate_int_range(data, issues, "settings.storage.thumbnails_retention_days", 1, 3650)
+    _validate_int_range(data, issues, "settings.storage.highres_temp_retention_hours", 1, 24 * 365)
+    _validate_int_range(data, issues, "settings.storage.max_exports_per_item", 1, 1000)
+    _validate_enum(
+        data,
+        issues,
+        "settings.library.default_mode",
+        {"operativa", "archivio"},
+    )
+    _validate_enum(
+        data,
+        issues,
+        "settings.defaults.preferred_ocr_engine",
+        {"openai", "anthropic", "google_vision", "kraken", "huggingface"},
+    )
+    _validate_enum(
+        data,
+        issues,
+        "settings.ocr.ocr_engine",
+        {"openai", "anthropic", "google_vision", "kraken", "huggingface"},
+    )
+    _validate_enum(
+        data,
+        issues,
+        "settings.images.download_strategy_mode",
+        {"balanced", "quality_first", "fast", "archival", "custom"},
+    )
+    _validate_enum(
+        data,
+        issues,
+        "settings.pdf.export.default_format",
+        {"pdf_images", "pdf_searchable", "pdf_facing"},
+    )
+    _validate_enum(
+        data,
+        issues,
+        "settings.pdf.export.default_compression",
+        {"High-Res", "Standard", "Light"},
+    )
+    _validate_enum(
+        data,
+        issues,
+        "settings.logging.level",
+        {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"},
+        normalize_case=True,
+    )
+    _validate_profile_default_exists(data, issues)
+    _validate_thumbnail_options(data, issues)
+
+
+def _validate_allowed_origins(data: dict[str, Any], issues: list[ConfigValidationIssue]) -> None:
+    exists, value = _get_path(data, "security.allowed_origins")
+    if not exists:
+        return
+    if not isinstance(value, list):
+        _add_error(
+            issues,
+            path="security.allowed_origins",
+            code="invalid_type",
+            message=f"Expected array of strings, got {_type_name(value)}.",
+        )
+        return
+    for idx, item in enumerate(value):
+        if not isinstance(item, str):
+            _add_error(
+                issues,
+                path=f"security.allowed_origins[{idx}]",
+                code="invalid_type",
+                message=f"Expected string, got {_type_name(item)}.",
+            )
+
+
+def _validate_profile_default_exists(data: dict[str, Any], issues: list[ConfigValidationIssue]) -> None:
+    default_exists, default_name = _get_path(data, "settings.pdf.profiles.default")
+    catalog_exists, catalog = _get_path(data, "settings.pdf.profiles.catalog")
+    if not default_exists or not catalog_exists:
+        return
+    if isinstance(default_name, str) and isinstance(catalog, dict) and default_name not in catalog:
+        _add_warning(
+            issues,
+            path="settings.pdf.profiles.default",
+            code="invalid_reference",
+            message=f"Default profile '{default_name}' is not present in catalog.",
+        )
+
+
+def _validate_thumbnail_options(data: dict[str, Any], issues: list[ConfigValidationIssue]) -> None:
+    exists, value = _get_path(data, "settings.thumbnails.page_size_options")
+    if not exists:
+        return
+    if not isinstance(value, list):
+        _add_warning(
+            issues,
+            path="settings.thumbnails.page_size_options",
+            code="invalid_type",
+            message=f"Expected array, got {_type_name(value)}.",
+        )
+        return
+    for idx, item in enumerate(value):
+        if not isinstance(item, int) or isinstance(item, bool):
+            _add_warning(
+                issues,
+                path=f"settings.thumbnails.page_size_options[{idx}]",
+                code="invalid_type",
+                message=f"Expected int, got {_type_name(item)}.",
+            )
+            continue
+        if not (1 <= item <= 120):
+            _add_warning(
+                issues,
+                path=f"settings.thumbnails.page_size_options[{idx}]",
+                code="out_of_range",
+                message=f"Expected value in range [1, 120], got {item}.",
+            )
+
+
+def _validate_enum(
+    data: dict[str, Any],
+    issues: list[ConfigValidationIssue],
+    path: str,
+    allowed_values: set[str],
+    *,
+    normalize_case: bool = False,
+) -> None:
+    exists, value = _get_path(data, path)
+    if not exists:
+        return
+    if not isinstance(value, str):
+        _add_warning(
+            issues,
+            path=path,
+            code="invalid_type",
+            message=f"Expected string enum, got {_type_name(value)}.",
+        )
+        return
+    candidate = value.upper() if normalize_case else value
+    if candidate not in allowed_values:
+        _add_warning(
+            issues,
+            path=path,
+            code="invalid_enum",
+            message=f"Unexpected enum value '{value}'.",
+        )
+
+
+def _validate_int_range(
+    data: dict[str, Any],
+    issues: list[ConfigValidationIssue],
+    path: str,
+    min_value: int,
+    max_value: int,
+) -> None:
+    exists, value = _get_path(data, path)
+    if not exists:
+        return
+    if not isinstance(value, int) or isinstance(value, bool):
+        _add_warning(
+            issues,
+            path=path,
+            code="invalid_type",
+            message=f"Expected int, got {_type_name(value)}.",
+        )
+        return
+    if not (min_value <= value <= max_value):
+        _add_warning(
+            issues,
+            path=path,
+            code="out_of_range",
+            message=f"Expected value in range [{min_value}, {max_value}], got {value}.",
+        )
+
+
+def _validate_float_range(
+    data: dict[str, Any],
+    issues: list[ConfigValidationIssue],
+    path: str,
+    min_value: float,
+    max_value: float,
+) -> None:
+    exists, value = _get_path(data, path)
+    if not exists:
+        return
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        _add_warning(
+            issues,
+            path=path,
+            code="invalid_type",
+            message=f"Expected number, got {_type_name(value)}.",
+        )
+        return
+    numeric = float(value)
+    if not (min_value <= numeric <= max_value):
+        _add_warning(
+            issues,
+            path=path,
+            code="out_of_range",
+            message=f"Expected value in range [{min_value}, {max_value}], got {numeric}.",
+        )
+
+
+def _path_exists(data: dict[str, Any], dotted_path: str) -> bool:
+    exists, _ = _get_path(data, dotted_path)
+    return exists
+
+
+def _get_path(data: dict[str, Any], dotted_path: str) -> tuple[bool, Any]:
+    node: Any = data
+    for part in dotted_path.split("."):
+        if not part:
+            continue
+        if not isinstance(node, dict) or part not in node:
+            return False, None
+        node = node[part]
+    return True, node
+
+
+def _matches_type(value: Any, expected: type[Any]) -> bool:
+    if expected is bool:
+        return isinstance(value, bool)
+    if expected is int:
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected is float:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, expected)
+
+
+def _type_name(value: Any) -> str:
+    return type(value).__name__
+
+
+def _join(base: str, key: str) -> str:
+    return f"{base}.{key}" if base else key
+
+
+def _add_warning(
+    issues: list[ConfigValidationIssue],
+    *,
+    path: str,
+    code: str,
+    message: str,
+) -> None:
+    issues.append(
+        ConfigValidationIssue(
+            severity=SEVERITY_WARNING,
+            path=path,
+            code=code,
+            message=message,
+        )
+    )
+
+
+def _add_error(
+    issues: list[ConfigValidationIssue],
+    *,
+    path: str,
+    code: str,
+    message: str,
+) -> None:
+    issues.append(
+        ConfigValidationIssue(
+            severity=SEVERITY_ERROR,
+            path=path,
+            code=code,
+            message=message,
+        )
+    )
+
+
+def _add_type_issue(
+    issues: list[ConfigValidationIssue],
+    *,
+    path: str,
+    expected: str,
+    value: Any,
+) -> None:
+    issue = ConfigValidationIssue(
+        severity=SEVERITY_ERROR if _is_critical_path(path) else SEVERITY_WARNING,
+        path=path,
+        code="invalid_type",
+        message=f"Expected {expected}, got {_type_name(value)}.",
+    )
+    issues.append(issue)
+
+
+def _is_critical_path(path: str) -> bool:
+    if path in {"$", ""}:
+        return True
+    return any(path == prefix or path.startswith(f"{prefix}.") for prefix in _CRITICAL_PREFIXES)

--- a/tests/test_config_manager_validation_logging.py
+++ b/tests/test_config_manager_validation_logging.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from universal_iiif_core.config_manager import DEFAULT_CONFIG_JSON, ConfigManager
+
+
+def _base_config() -> dict:
+    return json.loads(json.dumps(DEFAULT_CONFIG_JSON))
+
+
+def _write_config(path: Path, payload: dict) -> str:
+    text = json.dumps(payload, indent=2, ensure_ascii=False)
+    path.write_text(text, encoding="utf-8")
+    return text
+
+
+def test_load_logs_validation_issues_without_rewriting_file(tmp_path, caplog):
+    """Load should emit diagnostics while keeping file bytes untouched."""
+    cfg_path = tmp_path / "config.json"
+    payload = _base_config()
+    payload["security"]["allowed_origins"] = "http://localhost:8000"
+    payload["settings"]["thumbnails"]["columns"] = 6
+    payload["settings"]["unexpected"] = {"flag": True}
+    original = _write_config(cfg_path, payload)
+
+    caplog.set_level(logging.WARNING)
+    manager = ConfigManager.load(path=cfg_path)
+
+    assert manager.get_setting("thumbnails.columns") == 6
+    assert cfg_path.read_text(encoding="utf-8") == original
+    assert any(
+        rec.levelno >= logging.ERROR
+        and "security.allowed_origins" in rec.getMessage()
+        and "invalid_type" in rec.getMessage()
+        for rec in caplog.records
+    )
+    assert any(
+        rec.levelno == logging.WARNING
+        and "settings.thumbnails.columns" in rec.getMessage()
+        and "deprecated_key" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_load_does_not_log_secret_values(tmp_path, caplog):
+    """Validation output must not leak secret values."""
+    cfg_path = tmp_path / "config.json"
+    payload = _base_config()
+    payload["api_keys"]["openai"] = "sk-super-secret-value"
+    payload["api_keys"]["anthropic"] = {"token": "not-a-string"}
+    _write_config(cfg_path, payload)
+
+    caplog.set_level(logging.WARNING)
+    ConfigManager.load(path=cfg_path)
+
+    assert "sk-super-secret-value" not in caplog.text
+    assert "not-a-string" not in caplog.text

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+
+from universal_iiif_core.config_manager import DEFAULT_CONFIG_JSON
+from universal_iiif_core.config_validation import (
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    validate_config,
+)
+
+
+def _clone_default() -> dict:
+    return json.loads(json.dumps(DEFAULT_CONFIG_JSON))
+
+
+def test_validate_config_reports_deprecated_and_unknown_keys():
+    """Deprecated and unknown keys should produce warnings."""
+    data = _clone_default()
+    data["settings"]["thumbnails"]["columns"] = 6
+    data["settings"]["extra_section"] = {"foo": "bar"}
+    data["settings"]["pdf"]["profiles"]["catalog"]["custom_profile"] = {
+        **data["settings"]["pdf"]["profiles"]["catalog"]["balanced"],
+        "custom_field": "unused",
+    }
+
+    issues = validate_config(data, schema=DEFAULT_CONFIG_JSON)
+
+    assert any(
+        issue.severity == SEVERITY_WARNING
+        and issue.code == "deprecated_key"
+        and issue.path == "settings.thumbnails.columns"
+        for issue in issues
+    )
+    assert any(
+        issue.severity == SEVERITY_WARNING and issue.code == "unknown_key" and issue.path == "settings.extra_section"
+        for issue in issues
+    )
+    assert any(
+        issue.severity == SEVERITY_WARNING
+        and issue.code == "unknown_key"
+        and issue.path == "settings.pdf.profiles.catalog.custom_profile.custom_field"
+        for issue in issues
+    )
+
+
+def test_validate_config_reports_errors_for_critical_type_mismatch():
+    """Critical type mismatches should be reported as errors."""
+    data = _clone_default()
+    data["security"]["allowed_origins"] = "http://localhost:8000"
+    data["paths"] = "data/local"
+
+    issues = validate_config(data, schema=DEFAULT_CONFIG_JSON)
+
+    assert any(
+        issue.severity == SEVERITY_ERROR and issue.code == "invalid_type" and issue.path == "paths" for issue in issues
+    )
+    assert any(
+        issue.severity == SEVERITY_ERROR and issue.code == "invalid_type" and issue.path == "security.allowed_origins"
+        for issue in issues
+    )
+
+
+def test_validate_config_reports_out_of_range_values():
+    """Range checks should emit warnings for non-fatal anomalies."""
+    data = _clone_default()
+    data["settings"]["thumbnails"]["page_size"] = 500
+    data["settings"]["images"]["tile_stitch_max_ram_gb"] = 0.01
+
+    issues = validate_config(data, schema=DEFAULT_CONFIG_JSON)
+
+    assert any(
+        issue.severity == SEVERITY_WARNING
+        and issue.code == "out_of_range"
+        and issue.path == "settings.thumbnails.page_size"
+        for issue in issues
+    )
+    assert any(
+        issue.severity == SEVERITY_WARNING
+        and issue.code == "out_of_range"
+        and issue.path == "settings.images.tile_stitch_max_ram_gb"
+        for issue in issues
+    )


### PR DESCRIPTION
## Summary
- add global runtime validation for merged `config.json` with severity-based diagnostics
- keep validation non-mutating (logs only, no automatic config rewrite)
- integrate validation reporting in `ConfigManager.load()` and preserve masking of sensitive data

## Testing
- .venv/bin/pytest tests/test_config_validation.py tests/test_config_manager_validation_logging.py -v
- .venv/bin/pytest tests/
- .venv/bin/ruff check . --select C901

Closes #73