### PR TITLE
fix: prevent full-download action for paused/partial library items

### DIFF
--- a/src/studio_ui/components/library_cards.py
+++ b/src/studio_ui/components/library_cards.py
@@ -126,7 +126,7 @@ def _card_action_flags(doc: dict) -> dict[str, bool]:
     has_missing = bool(doc.get("has_missing_pages"))
     local_pages_count = int(doc.get("local_pages_count") or 0)
     return {
-        "download_full": not is_running and state != "complete",
+        "download_full": not is_running and state == "saved",
         "retry_missing": not is_running and has_missing,
         "cleanup_partial": not is_running and state in {"partial", "error"},
         "optimize_scans": not is_running and local_pages_count > 0,

--- a/src/studio_ui/routes/library_handlers.py
+++ b/src/studio_ui/routes/library_handlers.py
@@ -466,6 +466,19 @@ def library_start_download(
             action_required=action_required,
             sort_by=sort_by,
         )
+    if _effective_state(ms) != "saved":
+        return _refresh_response(
+            message="Download completo disponibile solo per documenti in stato Remoto.",
+            tone="info",
+            view=view,
+            q=q,
+            state=state,
+            library_filter=library_filter,
+            category=category,
+            mode=mode,
+            action_required=action_required,
+            sort_by=sort_by,
+        )
     try:
         start_downloader_thread(manifest_url, doc_id, library)
         return _refresh_response(

--- a/tests/test_library_components.py
+++ b/tests/test_library_components.py
@@ -1,4 +1,5 @@
 from studio_ui.components.library import render_library_card, render_library_page
+from studio_ui.components.library_cards import _card_action_flags
 
 
 def _base_doc(**overrides):
@@ -105,3 +106,11 @@ def test_library_archive_view_has_persisted_collapsible_sections():
     """Archive sections should expose stable collapsible keys for persistence."""
     rendered = repr(render_library_page([_base_doc()], mode="archivio", default_mode="operativa"))
     assert 'data-collapsible-key="archive:' in rendered
+
+
+def test_card_action_flags_enable_download_full_only_for_remote_state():
+    """'Scarica locale' must be enabled only for saved/remote items."""
+    assert _card_action_flags({"asset_state": "saved"}).get("download_full") is True
+    assert _card_action_flags({"asset_state": "partial"}).get("download_full") is False
+    assert _card_action_flags({"asset_state": "complete"}).get("download_full") is False
+    assert _card_action_flags({"asset_state": "error"}).get("download_full") is False

--- a/tests/test_library_handlers.py
+++ b/tests/test_library_handlers.py
@@ -205,6 +205,32 @@ def test_library_start_download_skips_complete_entries(monkeypatch):
     assert called["count"] == 0
 
 
+def test_library_start_download_rejects_non_remote_states(monkeypatch):
+    """Full download action should be enabled only for saved/remote manuscripts."""
+    vm = VaultManager()
+    vm.upsert_manuscript(
+        "DOC_PARTIAL",
+        library="Gallica",
+        manifest_url="https://example.org/m.json",
+        status="paused",
+        asset_state="partial",
+        total_canvases=10,
+        downloaded_canvases=4,
+    )
+
+    called = {"count": 0}
+
+    def _fake_start(*_a, **_k):
+        called["count"] += 1
+        return "jid"
+
+    monkeypatch.setattr(library_handlers, "start_downloader_thread", _fake_start)
+
+    result = library_handlers.library_start_download("DOC_PARTIAL", "Gallica")
+    assert "solo per documenti in stato Remoto" in repr(result)
+    assert called["count"] == 0
+
+
 def test_library_retry_missing_queues_specific_pages(monkeypatch):
     """Retry missing should enqueue only missing pages from missing_pages_json."""
     vm = VaultManager()


### PR DESCRIPTION
## Summary
- fixes Library card action matrix: `Scarica locale` is enabled only for `Remoto` (`saved`) items
- adds server-side guard in `/api/library/download_full` to reject non-remote states gracefully (no 500)
- adds regression tests for UI action flags and backend guard

## Why
When an item was paused/partial, UI incorrectly enabled full download; triggering it could produce a server error.

## Validation
- `./.venv/bin/ruff check src/studio_ui/components/library_cards.py src/studio_ui/routes/library_handlers.py tests/test_library_handlers.py tests/test_library_components.py`
- `./.venv/bin/pytest tests/test_library_handlers.py tests/test_library_components.py` (23 passed)

## Linked Issues
Related: #52
