### PR TITLE
fix: tighten studio image subtab action buttons

### DIFF
--- a/src/studio_ui/components/layout.py
+++ b/src/studio_ui/components/layout.py
@@ -731,13 +731,21 @@ def _style_tag():
         "monospace; text-align: right; }\n",
         ".dark .studio-thumb-dims-label { color: #94a3b8; }\n",
         ".dark .studio-thumb-dims-value { color: #e2e8f0; }\n",
-        ".studio-thumb-action { display: flex; align-items: center; gap: 0.35rem; min-width: 0; }\n",
+        ".studio-thumb-action { display: flex; align-items: stretch; gap: 0.3rem; min-width: 0; }\n",
+        ".studio-thumb-action .app-btn { align-self: stretch; }\n",
+        ".studio-thumb-action-inner { display: flex; align-items: center; justify-content: space-between; "
+        "gap: 0.35rem; width: 100%; min-width: 0; }\n",
+        ".studio-thumb-action-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; "
+        "white-space: nowrap; line-height: 1; }\n",
         ".studio-thumb-highres-btn { white-space: nowrap; font-size: 0.72rem !important; "
-        "padding: 0.34rem 0.5rem !important; flex: 1 1 auto; min-width: 0; }\n",
+        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
+        "overflow: hidden; }\n",
         ".studio-thumb-stitch-btn { white-space: nowrap; font-size: 0.72rem !important; "
-        "padding: 0.34rem 0.5rem !important; flex: 1 1 auto; min-width: 0; }\n",
+        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
+        "overflow: hidden; }\n",
         ".studio-thumb-opt-btn { white-space: nowrap; font-size: 0.72rem !important; "
-        "padding: 0.34rem 0.5rem !important; flex: 1 1 auto; min-width: 0; }\n",
+        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
+        "overflow: hidden; }\n",
         ".studio-thumb-progress { --progress: 0%; width: 0.88rem; height: 0.88rem; border-radius: 999px; "
         "flex: 0 0 0.88rem; display: inline-block; transform-origin: 50% 50%; will-change: transform; "
         "background: conic-gradient(var(--app-accent) var(--progress), rgba(148, 163, 184, 0.28) 0); "

--- a/src/studio_ui/components/studio/export.py
+++ b/src/studio_ui/components/studio/export.py
@@ -231,7 +231,7 @@ def render_export_thumbnail_card(
             Div(
                 Button(
                     Div(
-                        Span("⬇ Hi", cls="text-[12px] font-semibold"),
+                        Span("⬇ Hi", cls="studio-thumb-action-label text-[11px] font-semibold"),
                         Span(
                             "",
                             id=f"studio-thumb-progress-hi-{page}",
@@ -239,7 +239,7 @@ def render_export_thumbnail_card(
                             style=f"--progress:{hi_progress_percent}%;",
                             aria_hidden="true",
                         ),
-                        cls="flex items-center justify-between gap-2",
+                        cls="studio-thumb-action-inner",
                     ),
                     type="button",
                     hx_post=highres_url,
@@ -254,7 +254,7 @@ def render_export_thumbnail_card(
                 ),
                 Button(
                     Div(
-                        Span("🧩 Std", cls="text-[12px] font-semibold"),
+                        Span("🧩 Std", cls="studio-thumb-action-label text-[11px] font-semibold"),
                         Span(
                             "",
                             id=f"studio-thumb-progress-stitch-{page}",
@@ -262,7 +262,7 @@ def render_export_thumbnail_card(
                             style=f"--progress:{stitch_progress_percent}%;",
                             aria_hidden="true",
                         ),
-                        cls="flex items-center justify-between gap-2",
+                        cls="studio-thumb-action-inner",
                     ),
                     type="button",
                     hx_post=stitch_url,
@@ -280,7 +280,7 @@ def render_export_thumbnail_card(
                 ),
                 Button(
                     Div(
-                        Span("⚙ Opt", cls="text-[12px] font-semibold"),
+                        Span("⚙ Opt", cls="studio-thumb-action-label text-[11px] font-semibold"),
                         Span(
                             "",
                             id=f"studio-thumb-progress-opt-{page}",
@@ -288,7 +288,7 @@ def render_export_thumbnail_card(
                             style=f"--progress:{opt_progress_percent}%;",
                             aria_hidden="true",
                         ),
-                        cls="flex items-center justify-between gap-2",
+                        cls="studio-thumb-action-inner",
                     ),
                     type="button",
                     hx_post=optimize_url,

--- a/tests/test_studio_handlers.py
+++ b/tests/test_studio_handlers.py
@@ -700,6 +700,8 @@ def test_studio_export_page_highres_button_has_feedback_hooks(tmp_path):
     rendered = repr(panel)
     assert "studio-thumb-highres-btn" in rendered
     assert "studio-thumb-stitch-btn" in rendered
+    assert "studio-thumb-action-inner" in rendered
+    assert "studio-thumb-action-label" in rendered
     assert "studio-thumb-progress-" in rendered
     assert 'hx-target="#studio-thumb-card-1"' in rendered
     assert "/api/studio/export/page_stitch" in rendered


### PR DESCRIPTION
## Summary
- keep the `hi/std/opt` action buttons in the Studio Images subtab visually centered
- keep the loading dots and icons inside the button bounds by tightening the internal flex layout
- add a regression assertion for the thumbnail action markup

## Verification
- .venv/bin/pytest tests/test_studio_handlers.py -k "thumbs or remote_first or degraded_remote"
- .venv/bin/ruff check src/studio_ui/components/layout.py src/studio_ui/components/studio/export.py tests/test_studio_handlers.py

Related #68