### PR TITLE
fix: preserve gallica titles and add library delete modal

### DIFF
--- a/src/studio_ui/components/discovery.py
+++ b/src/studio_ui/components/discovery.py
@@ -55,7 +55,15 @@ def render_search_results_list(results: list) -> Div:
         elif library == "Institut de France" and doc_id:
             viewer_url = f"https://bibnum.institutdefrance.fr/viewer/{doc_id}"
 
-        hx_vals = json.dumps({"manifest_url": manifest_url, "doc_id": doc_id, "library": library}, ensure_ascii=True)
+        hx_vals = json.dumps(
+            {
+                "manifest_url": manifest_url,
+                "doc_id": doc_id,
+                "library": library,
+                "result_title": title,
+            },
+            ensure_ascii=True,
+        )
         badge_id = f"pdf-badge-{(doc_id or 'item').replace(' ', '-').replace('/', '-')[:28]}"
         pdf_badge = Div(
             "PDF: verifica automatica…",
@@ -355,6 +363,7 @@ def render_preview(data: dict) -> Div:
     description = data.get("description", "")
     thumbnail = data.get("thumbnail", "")
     has_native_pdf = data.get("has_native_pdf")
+    result_title = str(data.get("result_title") or label or "")
 
     # Warning se ci sono troppe pagine
     warning = None
@@ -443,7 +452,15 @@ def render_preview(data: dict) -> Div:
         cls="flex-grow",
     )
 
-    hx_vals = f'{{"manifest_url": "{manifest_url}", "doc_id": "{doc_id}", "library": "{library}"}}'
+    hx_vals = json.dumps(
+        {
+            "manifest_url": str(manifest_url or ""),
+            "doc_id": str(doc_id or ""),
+            "library": str(library or ""),
+            "result_title": result_title,
+        },
+        ensure_ascii=True,
+    )
     download_form = Div(
         Button(
             Span("➕ Aggiungi a Libreria", cls="font-bold"),

--- a/src/studio_ui/components/library.py
+++ b/src/studio_ui/components/library.py
@@ -30,7 +30,7 @@ def render_library_page(
     categories: list[str] | None = None,
 ) -> Div:
     """Render the full Local Library page."""
-    from .library_cards import _kpi_strip, _metadata_drawer, render_library_list
+    from .library_cards import _delete_modal, _kpi_strip, _metadata_drawer, render_library_list
     from .library_filters import (
         _library_filters_persistence_script,
         _normalize_mode,
@@ -75,6 +75,7 @@ def render_library_page(
         ),
         _library_filters_persistence_script(normalized_default_mode),
         render_library_list(docs, view=view, mode=current_mode),
+        _delete_modal(),
         _metadata_drawer(),
         cls="p-6 max-w-7xl mx-auto",
         id="library-page",

--- a/src/studio_ui/components/library_cards.py
+++ b/src/studio_ui/components/library_cards.py
@@ -133,15 +133,21 @@ def _card_action_flags(doc: dict) -> dict[str, bool]:
 
 
 def _delete_action(doc: dict, *, enabled: bool = True) -> Button:
-    doc_id = quote(str(doc.get("id") or ""), safe="")
-    library = quote(str(doc.get("library") or "Unknown"), safe="")
-    return _action_button(
+    base_cls = _ACTION_BUTTON_CLS["danger"]
+    if not enabled:
+        return Button(
+            "🗑️ Elimina",
+            type="button",
+            cls=f"{base_cls} opacity-45 cursor-not-allowed pointer-events-none",
+            disabled=True,
+            title="Disabilitato durante un download attivo.",
+        )
+    return Button(
         "🗑️ Elimina",
-        f"/api/library/delete?doc_id={doc_id}&library={library}",
-        "danger",
-        confirm="Confermi eliminazione completa del manoscritto locale?",
-        enabled=enabled,
-        hint="Disabilitato durante un download attivo." if not enabled else None,
+        type="button",
+        cls=base_cls,
+        data_payload=_delete_payload(doc),
+        onclick="openLibraryDeleteModal(this.dataset.payload)",
     )
 
 
@@ -357,6 +363,18 @@ def _metadata_payload(doc: dict) -> str:
         "source_detail_url": str(doc.get("source_detail_url") or ""),
         "user_notes": str(doc.get("user_notes") or ""),
         "metadata_items": _metadata_items(doc),
+    }
+    text = json.dumps(payload, ensure_ascii=True)
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _delete_payload(doc: dict) -> str:
+    payload = {
+        "doc_id": str(doc.get("id") or ""),
+        "library": str(doc.get("library") or "Unknown"),
+        "title": str(doc.get("display_title") or doc.get("id") or "Documento"),
+        "asset_state": str(doc.get("asset_state") or "saved"),
+        "shelfmark": str(doc.get("shelfmark") or doc.get("id") or "-"),
     }
     text = json.dumps(payload, ensure_ascii=True)
     return base64.b64encode(text.encode("utf-8")).decode("ascii")
@@ -729,6 +747,189 @@ def render_library_list(docs: list[dict], view: str = "grid", mode: str = "opera
     if (mode or "operativa").lower() == "archivio":
         return _render_archive_list(docs, view)
     return _render_operational_list(docs, view)
+
+
+def _delete_modal() -> Div:
+    return Div(
+        Div(
+            id="library-delete-overlay",
+            onclick="closeLibraryDeleteModal(event)",
+            cls="hidden fixed inset-0 z-40 bg-slate-900/55 backdrop-blur-[1px]",
+        ),
+        Div(
+            Div(
+                Div(
+                    H3(
+                        "Elimina documento",
+                        cls="text-lg font-semibold text-slate-900 dark:text-slate-100",
+                    ),
+                    Button(
+                        "✕",
+                        type="button",
+                        onclick="closeLibraryDeleteModal()",
+                        cls="text-lg text-slate-500 hover:text-slate-700 dark:text-slate-300 dark:hover:text-slate-100",
+                    ),
+                    cls="flex items-center justify-between border-b border-slate-200 dark:border-slate-700 px-4 py-3",
+                ),
+                Div(
+                    Div(
+                        P(
+                            "Stai per rimuovere questo item dalla Libreria locale.",
+                            cls="text-sm font-medium text-slate-700 dark:text-slate-200",
+                        ),
+                        P(
+                            (
+                                "L'operazione elimina file locali, cache del manifest "
+                                "e dati OCR associati. Non e reversibile."
+                            ),
+                            cls="text-sm text-slate-500 dark:text-slate-400",
+                        ),
+                        cls="space-y-1",
+                    ),
+                    Div(
+                        P(
+                            "",
+                            id="library-delete-doc-title",
+                            cls="text-base font-semibold text-slate-900 dark:text-slate-100",
+                        ),
+                        Div(
+                            Span("Segnatura:", cls="app-tech-key"),
+                            Span("-", id="library-delete-shelfmark", cls="app-tech-val"),
+                            cls="app-tech-row",
+                        ),
+                        Div(
+                            Span("Stato:", cls="app-tech-key"),
+                            Span("-", id="library-delete-state", cls="app-tech-val"),
+                            cls="app-tech-row",
+                        ),
+                        cls=(
+                            "rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 "
+                            "dark:bg-slate-800/60 p-3 space-y-2"
+                        ),
+                    ),
+                    cls="p-4 space-y-4 overflow-y-auto flex-1",
+                ),
+                Div(
+                    Button(
+                        "Annulla",
+                        type="button",
+                        onclick="closeLibraryDeleteModal()",
+                        cls=_ACTION_BUTTON_CLS["neutral"],
+                    ),
+                    Button(
+                        "Elimina definitivamente",
+                        id="library-delete-confirm",
+                        type="button",
+                        cls=_ACTION_BUTTON_CLS["danger"],
+                        hx_target="#library-page",
+                        hx_swap="outerHTML show:none",
+                        hx_include="#library-filters",
+                    ),
+                    cls="border-t border-slate-200 dark:border-slate-700 px-4 py-3 flex flex-wrap justify-end gap-2",
+                ),
+                cls=(
+                    "flex h-full flex-col bg-white dark:bg-slate-900 shadow-2xl "
+                    "rounded-t-2xl sm:rounded-none sm:rounded-2xl"
+                ),
+            ),
+            id="library-delete-sheet",
+            cls=(
+                "hidden fixed z-50 inset-x-0 bottom-0 max-h-[72vh] "
+                "sm:inset-0 sm:m-auto sm:h-auto sm:max-h-[420px] sm:w-[560px]"
+            ),
+        ),
+        Script(
+            """(function () {
+                if (window.__libraryDeleteModalBootstrapped) return;
+                window.__libraryDeleteModalBootstrapped = true;
+
+                function parsePayload(encoded) {
+                    if (!encoded) return null;
+                    try {
+                        return JSON.parse(atob(encoded));
+                    } catch (_error) {
+                        return null;
+                    }
+                }
+
+                function stateLabel(rawState) {
+                    var state = String(rawState || 'saved').toLowerCase();
+                    var labels = {
+                        saved: 'Remoto',
+                        partial: 'Parziale',
+                        complete: 'Completo',
+                        downloading: 'In download',
+                        running: 'In download',
+                        queued: 'In coda',
+                        error: 'Errore'
+                    };
+                    return labels[state] || state;
+                }
+
+                function modalElements() {
+                    return {
+                        overlay: document.getElementById('library-delete-overlay'),
+                        sheet: document.getElementById('library-delete-sheet'),
+                        title: document.getElementById('library-delete-doc-title'),
+                        shelfmark: document.getElementById('library-delete-shelfmark'),
+                        state: document.getElementById('library-delete-state'),
+                        confirm: document.getElementById('library-delete-confirm')
+                    };
+                }
+
+                window.openLibraryDeleteModal = function (encoded) {
+                    var data = parsePayload(encoded);
+                    var els = modalElements();
+                    if (
+                        !data || !els.overlay || !els.sheet || !els.title ||
+                        !els.shelfmark || !els.state || !els.confirm
+                    ) {
+                        return;
+                    }
+                    if (typeof window.closeLibraryMetadata === 'function') {
+                        window.closeLibraryMetadata();
+                    }
+
+                    els.title.textContent = String(data.title || data.doc_id || 'Documento');
+                    els.shelfmark.textContent = String(data.shelfmark || data.doc_id || '-');
+                    els.state.textContent = stateLabel(data.asset_state);
+                    els.confirm.setAttribute(
+                        'hx-post',
+                        '/api/library/delete?doc_id='
+                            + encodeURIComponent(String(data.doc_id || ''))
+                            + '&library='
+                            + encodeURIComponent(String(data.library || 'Unknown'))
+                    );
+                    if (window.htmx && typeof window.htmx.process === 'function') {
+                        window.htmx.process(els.confirm);
+                    }
+
+                    els.overlay.classList.remove('hidden');
+                    els.sheet.classList.remove('hidden');
+                    document.body.classList.add('overflow-hidden');
+                };
+
+                window.closeLibraryDeleteModal = function (event) {
+                    if (event && event.target && event.target.id !== 'library-delete-overlay') return;
+                    var els = modalElements();
+                    if (els.overlay) els.overlay.classList.add('hidden');
+                    if (els.sheet) els.sheet.classList.add('hidden');
+                    document.body.classList.remove('overflow-hidden');
+                };
+
+                document.addEventListener('keydown', function(event) {
+                    if (event.key === 'Escape') window.closeLibraryDeleteModal();
+                });
+
+                document.body.addEventListener('htmx:afterRequest', function(event) {
+                    var trigger = event && event.detail && event.detail.elt;
+                    if (trigger && trigger.id === 'library-delete-confirm') {
+                        window.closeLibraryDeleteModal();
+                    }
+                });
+            })();"""
+        ),
+    )
 
 
 def _metadata_drawer() -> Div:

--- a/src/studio_ui/routes/discovery_handlers.py
+++ b/src/studio_ui/routes/discovery_handlers.py
@@ -11,9 +11,8 @@ from urllib.parse import unquote
 
 from fasthtml.common import Request
 
+from studio_ui.common.title_utils import resolve_preferred_title
 from studio_ui.common.toasts import build_toast
-
-# Importiamo i nuovi componenti grafici
 from studio_ui.components.discovery import (
     discovery_content,
     render_download_manager,
@@ -102,6 +101,30 @@ def _is_manuscript_complete(row: dict | None) -> bool:
     return total > 0 and downloaded >= total
 
 
+def _resolve_saved_entry_title(info: dict, doc_id: str, *, result_title: str = "") -> str:
+    """Choose the strongest human title available for a saved discovery entry."""
+    clean_doc_id = str(doc_id or "").strip()
+    clean_result_title = str(result_title or "").strip()
+    clean_shelfmark = str(info.get("shelfmark") or "").strip()
+    preferred = str(
+        resolve_preferred_title(
+            {
+                "id": clean_doc_id,
+                "catalog_title": str(info.get("catalog_title") or "").strip(),
+                "display_title": str(info.get("label") or "").strip(),
+                "title": str(info.get("label") or "").strip(),
+                "reference_text": clean_result_title or str(info.get("reference_text") or "").strip(),
+                "shelfmark": clean_shelfmark,
+            },
+            fallback_doc_id=clean_doc_id,
+        )
+        or ""
+    ).strip()
+    if clean_result_title and preferred in {"", clean_doc_id, clean_shelfmark}:
+        return clean_result_title
+    return preferred or clean_result_title or clean_doc_id or "Senza Titolo"
+
+
 def _upsert_saved_entry(
     manifest_url: str,
     doc_id: str,
@@ -126,8 +149,15 @@ def _upsert_saved_entry(
     metadata_json: str = "{}",
     manifest_local_available: bool = False,
     thumbnail_url: str = "",
+    preferred_title: str = "",
 ) -> None:
-    entry_label = (label or doc_id or "Senza Titolo").strip()
+    entry_label = (
+        str(preferred_title or "").strip()
+        or str(label or "").strip()
+        or str(catalog_title or "").strip()
+        or str(doc_id or "").strip()
+        or "Senza Titolo"
+    )
     total = int(pages or 0)
     v = VaultManager()
     existing = _find_manuscript_by_id_and_library(doc_id, library) or {}
@@ -144,11 +174,14 @@ def _upsert_saved_entry(
     existing_thumbnail = str(existing.get("thumbnail_url") or "").strip()
     source_mode = str(existing.get("read_source_mode") or "remote").strip().lower() or "remote"
     thumbnail_to_store = str(thumbnail_url or existing_thumbnail or "").strip()
+    catalog_title_to_store = str(catalog_title or "").strip() or entry_label
+    if str(preferred_title or "").strip():
+        catalog_title_to_store = str(preferred_title).strip()
     v.upsert_manuscript(
         doc_id,
         display_title=entry_label,
         title=entry_label,
-        catalog_title=(catalog_title or "").strip() or entry_label,
+        catalog_title=catalog_title_to_store,
         library=library,
         manifest_url=manifest_url,
         local_path=str(_downloads_doc_path(library, doc_id)),
@@ -356,11 +389,13 @@ def discovery_page(request: Request):
 
 def _build_item_preview_data(item: dict, library: str, pages: int = 0) -> dict:
     """Build preview payload from a search result item."""
+    result_title = item.get("title", "Senza Titolo")
     return {
         "id": item.get("id"),
         "library": library,
         "url": item.get("manifest"),
-        "label": item.get("title", "Senza Titolo"),
+        "label": result_title,
+        "result_title": result_title,
         "description": item.get("description", ""),
         "pages": pages,
         "thumbnail": item.get("thumbnail"),
@@ -370,11 +405,13 @@ def _build_item_preview_data(item: dict, library: str, pages: int = 0) -> dict:
 
 def _build_manifest_preview_data(manifest_info: dict, manifest_url: str, doc_id: str | None, library: str) -> dict:
     """Build preview payload from analyzed manifest metadata."""
+    label = manifest_info.get("catalog_title") or manifest_info.get("label", "Senza Titolo")
     return {
         "id": doc_id or manifest_info.get("label", "Unknown"),
         "library": library,
         "url": manifest_url,
-        "label": manifest_info.get("catalog_title") or manifest_info.get("label", "Senza Titolo"),
+        "label": label,
+        "result_title": label,
         "description": manifest_info.get("description", "Nessuna descrizione."),
         "pages": manifest_info.get("pages", 0),
         "thumbnail": manifest_info.get("thumbnail"),
@@ -570,22 +607,25 @@ def resolve_manifest(library: str, shelfmark: str, gallica_type: str = "all"):
         )
 
 
-def add_to_library(manifest_url: str, doc_id: str, library: str):
+def add_to_library(manifest_url: str, doc_id: str, library: str, result_title: str = ""):
     """Persist a manuscript in Library without starting a download."""
     try:
         manifest_url = unquote(manifest_url)
         doc_id = unquote(doc_id)
         library = unquote(library)
+        result_title = unquote(result_title)
         if not manifest_url or not doc_id or not library:
             return _with_feedback_toast("Dati mancanti", "Manifest, ID e biblioteca sono obbligatori.", tone="danger")
 
         info, _err = _analyze_manifest_safe(manifest_url)
         info = info or {}
+        preferred_title = _resolve_saved_entry_title(info, doc_id, result_title=result_title)
+        reference_text = str(info.get("reference_text") or result_title or "").strip()
         manifest_cached, prefetch_thumb = _persist_prefetch_light(
             manifest_url,
             doc_id,
             library,
-            title=str(info.get("catalog_title") or info.get("label") or doc_id),
+            title=preferred_title,
             description=str(info.get("description") or ""),
             pages=int(info.get("pages", 0) or 0),
             thumbnail_url=str(info.get("thumbnail") or ""),
@@ -606,13 +646,14 @@ def add_to_library(manifest_url: str, doc_id: str, library: str):
             date_label=info.get("date_label", ""),
             language_label=info.get("language_label", ""),
             source_detail_url=info.get("source_detail_url", ""),
-            reference_text=info.get("reference_text", ""),
+            reference_text=reference_text,
             item_type=info.get("item_type", "non classificato"),
             item_type_confidence=float(info.get("item_type_confidence", 0.0) or 0.0),
             item_type_reason=info.get("item_type_reason", ""),
             metadata_json=info.get("metadata_json", "{}"),
             manifest_local_available=manifest_cached,
             thumbnail_url=prefetch_thumb,
+            preferred_title=preferred_title,
         )
         return _with_toast(
             _download_manager_fragment(),
@@ -627,12 +668,13 @@ def add_to_library(manifest_url: str, doc_id: str, library: str):
         return _with_feedback_toast("Errore Libreria", "Impossibile salvare l'entry in Libreria.", tone="danger")
 
 
-def add_and_download(manifest_url: str, doc_id: str, library: str):
+def add_and_download(manifest_url: str, doc_id: str, library: str, result_title: str = ""):
     """Persist a manuscript and enqueue download."""
     try:
         manifest_url = unquote(manifest_url)
         doc_id = unquote(doc_id)
         library = unquote(library)
+        result_title = unquote(result_title)
         if not manifest_url or not doc_id or not library:
             return _with_feedback_toast("Dati mancanti", "Manifest, ID e biblioteca sono obbligatori.", tone="danger")
 
@@ -646,11 +688,13 @@ def add_and_download(manifest_url: str, doc_id: str, library: str):
 
         info, _err = _analyze_manifest_safe(manifest_url)
         info = info or {}
+        preferred_title = _resolve_saved_entry_title(info, doc_id, result_title=result_title)
+        reference_text = str(info.get("reference_text") or result_title or "").strip()
         manifest_cached, prefetch_thumb = _persist_prefetch_light(
             manifest_url,
             doc_id,
             library,
-            title=str(info.get("catalog_title") or info.get("label") or doc_id),
+            title=preferred_title,
             description=str(info.get("description") or ""),
             pages=int(info.get("pages", 0) or 0),
             thumbnail_url=str(info.get("thumbnail") or ""),
@@ -671,13 +715,14 @@ def add_and_download(manifest_url: str, doc_id: str, library: str):
             date_label=info.get("date_label", ""),
             language_label=info.get("language_label", ""),
             source_detail_url=info.get("source_detail_url", ""),
-            reference_text=info.get("reference_text", ""),
+            reference_text=reference_text,
             item_type=info.get("item_type", "non classificato"),
             item_type_confidence=float(info.get("item_type_confidence", 0.0) or 0.0),
             item_type_reason=info.get("item_type_reason", ""),
             metadata_json=info.get("metadata_json", "{}"),
             manifest_local_available=manifest_cached,
             thumbnail_url=prefetch_thumb,
+            preferred_title=preferred_title,
         )
 
         download_id = start_downloader_thread(manifest_url, doc_id, library)
@@ -701,9 +746,9 @@ def add_and_download(manifest_url: str, doc_id: str, library: str):
         )
 
 
-def start_download(manifest_url: str, doc_id: str, library: str):
+def start_download(manifest_url: str, doc_id: str, library: str, result_title: str = ""):
     """Backward-compatible endpoint kept for legacy callers."""
-    return add_and_download(manifest_url, doc_id, library)
+    return add_and_download(manifest_url, doc_id, library, result_title=result_title)
 
 
 def get_download_status(download_id: str, doc_id: str = "", library: str = ""):

--- a/tests/test_discovery_download_manager.py
+++ b/tests/test_discovery_download_manager.py
@@ -39,6 +39,49 @@ def test_add_to_library_persists_saved_entry(monkeypatch):
     assert (doc_data / "manifest.json").exists()
 
 
+@pytest.mark.parametrize("handler_name", ["add_to_library", "add_and_download"])
+def test_discovery_preserves_search_result_title_over_signature_manifest(monkeypatch, handler_name):
+    """Discovery should keep the human search-result title when manifest metadata looks like a shelfmark."""
+    monkeypatch.setattr(
+        discovery_handlers,
+        "analyze_manifest",
+        lambda _url: {
+            "label": "BnF, département Littérature et art, V-9536",
+            "catalog_title": "BnF, département Littérature et art, V-9536",
+            "description": "Manuale schermistico",
+            "pages": 8,
+            "shelfmark": "BnF, département Littérature et art, V-9536",
+            "reference_text": "Esercizio di spada",
+        },
+    )
+    monkeypatch.setattr(
+        discovery_handlers,
+        "get_json",
+        lambda _url, retries=2: {"items": [{"id": "canvas-1"}]},
+    )
+    monkeypatch.setattr(
+        discovery_handlers,
+        "start_downloader_thread",
+        lambda *_args, **_kwargs: "job-title-fix",
+    )
+
+    handler = getattr(discovery_handlers, handler_name)
+    result = handler(
+        "https://example.org/manifest.json",
+        "bpt6k1234567",
+        "Gallica",
+        "Esercizio di spada",
+    )
+
+    assert ("Aggiunto in Libreria" in repr(result)) or ("Download accodato" in repr(result))
+    ms = VaultManager().get_manuscript("bpt6k1234567") or {}
+    assert ms.get("display_title") == "Esercizio di spada"
+    assert ms.get("title") == "Esercizio di spada"
+    assert ms.get("catalog_title") == "Esercizio di spada"
+    assert ms.get("shelfmark") == "BnF, département Littérature et art, V-9536"
+    assert ms.get("reference_text") == "Esercizio di spada"
+
+
 def test_add_to_library_rejects_path_traversal_and_does_not_write(monkeypatch, tmp_path):
     """Traversal in library/doc_id must be rejected before any filesystem write."""
     cm = get_config_manager()

--- a/tests/test_library_components.py
+++ b/tests/test_library_components.py
@@ -95,6 +95,23 @@ def test_library_page_uses_configurable_default_mode_in_script():
     assert 'const DEFAULT_MODE = "archivio";' in rendered
 
 
+def test_library_delete_uses_styled_modal_instead_of_native_confirm():
+    """Delete action should use the app modal instead of browser confirm dialogs."""
+    rendered = repr(render_library_card(_base_doc()))
+    assert "openLibraryDeleteModal(" in rendered
+    assert "hx_confirm" not in rendered
+
+
+def test_library_page_includes_delete_modal_shell():
+    """Library page should include the shared delete modal and script hooks."""
+    rendered = repr(render_library_page([_base_doc()]))
+    assert 'id="library-delete-overlay"' in rendered
+    assert 'id="library-delete-sheet"' in rendered
+    assert 'id="library-delete-confirm"' in rendered
+    assert "window.openLibraryDeleteModal" in rendered
+    assert "window.closeLibraryDeleteModal" in rendered
+
+
 def test_library_card_truncates_long_title():
     """Card title should be truncated for very long labels."""
     long_title = "Titolo molto lungo " * 10


### PR DESCRIPTION
## Summary
- preserve the Discovery search-result title when Gallica manifests expose a shelfmark-like label
- keep Library items aligned by storing the preferred human title instead of the manifest signature
- replace the native delete confirm with an app-styled Library modal

## Verification
- .venv/bin/pytest tests/test_discovery_download_manager.py tests/test_library_components.py
- .venv/bin/ruff check src/studio_ui/components/discovery.py src/studio_ui/routes/discovery_handlers.py src/studio_ui/components/library_cards.py src/studio_ui/components/library.py tests/test_discovery_download_manager.py tests/test_library_components.py

Related #7