### PR TITLE
fix: resolve hanging tests and add pytest-timeout safeguard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install pytest ruff
+        pip install pytest pytest-timeout ruff
         
     - name: Lint with Ruff
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ indent-style = "space"
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q"
+timeout = 60
 testpaths = ["tests"]
 python_files = "test_*.py"
 markers = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pyright
 
 # Testing
 pytest
+pytest-timeout

--- a/src/studio_ui/routes/discovery_handlers.py
+++ b/src/studio_ui/routes/discovery_handlers.py
@@ -365,7 +365,9 @@ def add_to_library(manifest_url: str, doc_id: str, library: str, result_title: s
         if not manifest_url or not doc_id or not library:
             return _with_feedback_toast("Dati mancanti", "Manifest, ID e biblioteca sono obbligatori.", tone="danger")
 
-        info, _err = _analyze_manifest_safe(manifest_url)
+        info, manifest_err = _analyze_manifest_safe(manifest_url)
+        if manifest_err is not None:
+            return manifest_err
         info = info or {}
         preferred_title = resolve_saved_entry_title(info, doc_id, result_title=result_title)
         reference_text = str(info.get("reference_text") or result_title or "").strip()
@@ -435,7 +437,9 @@ def add_and_download(manifest_url: str, doc_id: str, library: str, result_title:
                 tone="info",
             )
 
-        info, _err = _analyze_manifest_safe(manifest_url)
+        info, manifest_err = _analyze_manifest_safe(manifest_url)
+        if manifest_err is not None:
+            return manifest_err
         info = info or {}
         preferred_title = resolve_saved_entry_title(info, doc_id, result_title=result_title)
         reference_text = str(info.get("reference_text") or result_title or "").strip()

--- a/tests/test_security_routing.py
+++ b/tests/test_security_routing.py
@@ -147,6 +147,37 @@ def test_exception_sanitization_start_download(monkeypatch):
     )
 
 
+def test_add_to_library_returns_early_on_manifest_error(monkeypatch):
+    """Regression: add_to_library must not call persist_prefetch_light when manifest analysis fails."""
+    from studio_ui.routes import discovery_handlers
+
+    monkeypatch.setattr(discovery_handlers, "analyze_manifest", lambda _: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    called = []
+    monkeypatch.setattr(discovery_handlers, "persist_prefetch_light", lambda *a, **kw: called.append(1) or ("", ""))
+
+    result = discovery_handlers.add_to_library("https://bad-url", "doc", "Lib")
+
+    assert not called, "persist_prefetch_light should not be called when manifest analysis fails"
+    assert "Errore" in str(result)
+
+
+def test_add_and_download_returns_early_on_manifest_error(monkeypatch):
+    """Regression: add_and_download must not call persist_prefetch_light when manifest analysis fails."""
+    from studio_ui.routes import discovery_handlers
+
+    monkeypatch.setattr(discovery_handlers, "analyze_manifest", lambda _: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    called = []
+    monkeypatch.setattr(discovery_handlers, "persist_prefetch_light", lambda *a, **kw: called.append(1) or ("", ""))
+    monkeypatch.setattr(discovery_handlers, "start_downloader_thread", lambda *a, **kw: "jid")
+
+    result = discovery_handlers.add_and_download("https://bad-url", "doc", "Lib")
+
+    assert not called, "persist_prefetch_light should not be called when manifest analysis fails"
+    assert "Errore" in str(result)
+
+
 def test_path_validation_with_symlinks(tmp_path):
     """Ensure symlinks cannot escape downloads_dir."""
     config = get_config_manager()


### PR DESCRIPTION
## Summary

- Confirm #117 is resolved: all 4 previously hanging tests now pass (399 passed, 0 hanging in full suite)
- Fix silent error in `add_and_download` / `save_to_library`: manifest analysis errors were ignored via `_err`, causing the function to proceed with real HTTP calls to invalid URLs
- Add `pytest-timeout` (60s default) as dev dependency to prevent future test hangs

## Root cause

The original 4 hanging tests were caused by the legacy HTTP session layer (pre-HTTPClient migration). The fix in `c88348a` (HTTPClient migration, #116) resolved the underlying deadlock/hang.

The remaining `test_exception_sanitization_start_download` timeout was a secondary bug: `_analyze_manifest_safe` returned an error toast that was silently discarded (`_err`), so the code continued to `persist_prefetch_light` which made real HTTP calls with retries to an invalid URL.

## Changes

| File | Change |
|------|--------|
| `discovery_handlers.py` | Return early when `_analyze_manifest_safe` fails (2 call sites) |
| `pyproject.toml` | Add `timeout = 60` to pytest config |
| `requirements-dev.txt` | Add `pytest-timeout` |

Closes #117

## Test plan

- [x] `pytest tests/` — 399 passed, 5 skipped, 0 failed (1:53)
- [x] `pytest tests/test_security_routing.py` — 8 passed in 0.99s (was 65s)
- [x] `ruff check` + `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)