### PR TITLE
refactor: decouple provider registry from direct resolver imports (#104)

### DIFF
--- a/src/universal_iiif_core/discovery/search_adapters.py
+++ b/src/universal_iiif_core/discovery/search_adapters.py
@@ -142,7 +142,13 @@ def build_search_strategy_handlers(
     search_loc_fn: SearchWithLimitFn,
     search_heidelberg_fn: SearchWithLimitFn,
 ) -> dict[str, Callable[[str, dict[str, Any]], list[SearchResult]]]:
-    """Build provider search strategy handlers from injected adapter callables."""
+    """Build provider search strategy handlers from injected adapter callables.
+
+    .. deprecated::
+        Use :func:`universal_iiif_core.providers.get_search_handlers` instead.
+        This function is retained for backward-compatible test injection only
+        and will be removed when search functions are decomposed (#118).
+    """
     return {
         "archive_org": lambda query, payload: _search_archive_provider(
             query,

--- a/src/universal_iiif_core/providers.py
+++ b/src/universal_iiif_core/providers.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from universal_iiif_core.logger import get_logger
 from universal_iiif_core.resolvers.archive_org import ArchiveOrgResolver
@@ -60,6 +61,7 @@ class IIIFProvider:
     aliases: tuple[str, ...]
     resolver_cls: type[BaseResolver]
     search_strategy: SearchStrategy | None = None
+    search_fn: str | None = None
     search_mode: SearchMode = "direct"
     filters: tuple[ProviderFilter, ...] = ()
     not_found_hint: str = "Verifica la segnatura."
@@ -99,6 +101,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("vaticana", "vaticana (bav)", "vatican"),
         resolver_cls=VaticanResolver,
         search_strategy="vatican",
+        search_fn="search_vatican",
         search_mode="fallback",
         not_found_hint=(
             "Verifica la segnatura. Prova formati come 'Urb.lat.1779' o inserisci solo il numero (es. '1223')."
@@ -112,6 +115,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("gallica", "gallica (bnf)", "bnf"),
         resolver_cls=GallicaResolver,
         search_strategy="gallica",
+        search_fn="smart_search",
         search_mode="search_first",
         filters=(_GALLICA_FILTER,),
         not_found_hint="Verifica l'ID ARK, l'URL o la ricerca testuale.",
@@ -124,6 +128,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("institut de france", "institut de france (bibnum)", "institut", "bibnum"),
         resolver_cls=InstitutResolver,
         search_strategy="institut",
+        search_fn="search_institut",
         search_mode="fallback",
         not_found_hint="Verifica la segnatura. Usa ID numerico (es. '17837'), URL viewer o una ricerca testuale.",
         placeholder="es. 17837",
@@ -135,6 +140,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("bodleian", "bodleian (oxford)", "oxford"),
         resolver_cls=OxfordResolver,
         search_strategy="bodleian",
+        search_fn="search_bodleian",
         not_found_hint="Verifica l'UUID o incolla un URL Digital Bodleian valido.",
         placeholder="es. 080f88f5-7586-4b8a-8064-63ab3495393c",
         sort_order=40,
@@ -145,6 +151,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("heidelberg", "universitaetsbibliothek heidelberg", "universitätsbibliothek heidelberg"),
         resolver_cls=HeidelbergResolver,
         search_strategy="heidelberg",
+        search_fn="search_heidelberg",
         search_mode="fallback",
         not_found_hint=(
             "Per ora la ricerca libera Heidelberg puo richiedere il browser del catalogo. "
@@ -166,6 +173,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("cambridge", "cambridge university digital library", "cudl"),
         resolver_cls=CambridgeResolver,
         search_strategy="cambridge",
+        search_fn="search_cambridge",
         search_mode="fallback",
         not_found_hint=(
             "Per ora la ricerca libera richiede il browser CUDL. "
@@ -185,6 +193,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("e-codices", "ecodices"),
         resolver_cls=EcodicesResolver,
         search_strategy="ecodices",
+        search_fn="search_ecodices",
         not_found_hint="Incolla un URL e-codices o un ID composto tipo 'csg-0001'.",
         placeholder="es. csg-0001",
         sort_order=70,
@@ -195,6 +204,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("harvard", "harvard university"),
         resolver_cls=HarvardResolver,
         search_strategy="harvard",
+        search_fn="search_harvard",
         search_mode="fallback",
         not_found_hint="Incolla un URL Harvard IIIF/Hollis con DRS ID.",
         placeholder="es. https://iiif.lib.harvard.edu/manifests/view/drs:12345678",
@@ -206,6 +216,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("library of congress", "loc"),
         resolver_cls=LOCResolver,
         search_strategy="loc",
+        search_fn="search_loc",
         search_mode="fallback",
         not_found_hint="Incolla un URL loc.gov/item/... valido.",
         placeholder="es. https://www.loc.gov/item/2021668145/",
@@ -217,6 +228,7 @@ PROVIDERS: tuple[IIIFProvider, ...] = (
         aliases=("archive.org", "internet archive", "archive"),
         resolver_cls=ArchiveOrgResolver,
         search_strategy="archive_org",
+        search_fn="search_archive_org",
         search_mode="search_first",
         not_found_hint="Incolla un URL archive.org/details/... o un manifest iiif.archive.org valido.",
         placeholder="es. https://archive.org/details/b29000427_0001",
@@ -300,12 +312,96 @@ def resolve_with_provider(value: str, *, include_generic: bool = True) -> tuple[
     return None, None, _PROVIDER_BY_KEY["Unknown"]
 
 
+# ---------------------------------------------------------------------------
+# Search handler construction (lazy-loaded from resolvers.discovery)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MAX_RESULTS = 20
+
+SearchHandlerFn = Callable[[str, dict[str, Any]], list[Any]]
+
+
+def _max_results_from_payload(payload: dict[str, Any]) -> int:
+    """Read max_results from the adapter payload, falling back to the default."""
+    raw = payload.get("max_results")
+    if raw is not None:
+        try:
+            return max(1, min(int(raw), 50))
+        except (TypeError, ValueError):
+            pass
+    return _DEFAULT_MAX_RESULTS
+
+
+def _page_from_payload(payload: dict[str, Any]) -> int:
+    """Read page number from the adapter payload (1-based, default 1)."""
+    raw = payload.get("page")
+    if raw is not None:
+        try:
+            return max(1, int(raw))
+        except (TypeError, ValueError):
+            pass
+    return 1
+
+
+def _make_standard_adapter(fn: Callable[..., list[Any]]) -> SearchHandlerFn:
+    """Wrap a (query, max_results, page) search fn into the (query, payload) interface."""
+
+    def _adapter(query: str, payload: dict[str, Any]) -> list[Any]:
+        return fn(query, _max_results_from_payload(payload), _page_from_payload(payload))
+
+    return _adapter
+
+
+def _make_gallica_adapter(fn: Callable[..., list[Any]]) -> SearchHandlerFn:
+    """Wrap the Gallica smart_search fn, forwarding gallica_type_filter from payload."""
+
+    def _adapter(query: str, payload: dict[str, Any]) -> list[Any]:
+        return fn(
+            query,
+            max_records=_max_results_from_payload(payload),
+            page=_page_from_payload(payload),
+            gallica_type_filter=str(payload.get("gallica_type") or "all"),
+        )
+
+    return _adapter
+
+
+_search_handlers_cache: dict[str, SearchHandlerFn] | None = None
+
+
+def get_search_handlers() -> dict[str, SearchHandlerFn]:
+    """Build the search-strategy dispatch dict from the provider registry.
+
+    Search functions are lazy-imported from ``resolvers.discovery`` to avoid
+    circular imports at module load time.  The result is cached after first call.
+    """
+    global _search_handlers_cache  # noqa: PLW0603
+    if _search_handlers_cache is not None:
+        return _search_handlers_cache
+
+    from universal_iiif_core.resolvers import discovery as _disc
+
+    handlers: dict[str, SearchHandlerFn] = {}
+    for provider in PROVIDERS:
+        if not provider.search_strategy or not provider.search_fn:
+            continue
+        raw_fn = getattr(_disc, provider.search_fn)
+        if provider.search_strategy == "gallica":
+            handlers[provider.search_strategy] = _make_gallica_adapter(raw_fn)
+        else:
+            handlers[provider.search_strategy] = _make_standard_adapter(raw_fn)
+
+    _search_handlers_cache = handlers
+    return handlers
+
+
 __all__ = [
     "IIIFProvider",
     "PROVIDERS",
     "ProviderFilter",
     "ProviderFilterOption",
     "get_provider",
+    "get_search_handlers",
     "is_known_provider",
     "iter_providers",
     "normalize_provider_value",

--- a/src/universal_iiif_core/providers.py
+++ b/src/universal_iiif_core/providers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import types
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -15,6 +16,7 @@ from universal_iiif_core.resolvers.harvard import HarvardResolver
 from universal_iiif_core.resolvers.heidelberg import HeidelbergResolver
 from universal_iiif_core.resolvers.institut import InstitutResolver
 from universal_iiif_core.resolvers.loc import LOCResolver
+from universal_iiif_core.resolvers.models import SearchResult
 from universal_iiif_core.resolvers.oxford import OxfordResolver
 from universal_iiif_core.resolvers.vatican import VaticanResolver
 
@@ -75,8 +77,8 @@ class IIIFProvider:
         return self.resolver_cls()
 
     def supports_search(self) -> bool:
-        """Return True when the provider exposes a search strategy."""
-        return self.search_strategy is not None
+        """Return True when the provider has both a search strategy and a wired handler."""
+        return self.search_strategy is not None and self.search_fn is not None
 
     def supports_direct_resolution(self) -> bool:
         """Return True when the provider has a dedicated resolver."""
@@ -316,46 +318,27 @@ def resolve_with_provider(value: str, *, include_generic: bool = True) -> tuple[
 # Search handler construction (lazy-loaded from resolvers.discovery)
 # ---------------------------------------------------------------------------
 
-_DEFAULT_MAX_RESULTS = 20
+from universal_iiif_core.discovery.search_adapters import (  # noqa: E402
+    _max_results_from_payload,
+    _page_from_payload,
+)
 
-SearchHandlerFn = Callable[[str, dict[str, Any]], list[Any]]
-
-
-def _max_results_from_payload(payload: dict[str, Any]) -> int:
-    """Read max_results from the adapter payload, falling back to the default."""
-    raw = payload.get("max_results")
-    if raw is not None:
-        try:
-            return max(1, min(int(raw), 50))
-        except (TypeError, ValueError):
-            pass
-    return _DEFAULT_MAX_RESULTS
+SearchHandlerFn = Callable[[str, dict[str, Any]], list[SearchResult]]
 
 
-def _page_from_payload(payload: dict[str, Any]) -> int:
-    """Read page number from the adapter payload (1-based, default 1)."""
-    raw = payload.get("page")
-    if raw is not None:
-        try:
-            return max(1, int(raw))
-        except (TypeError, ValueError):
-            pass
-    return 1
-
-
-def _make_standard_adapter(fn: Callable[..., list[Any]]) -> SearchHandlerFn:
+def _make_standard_adapter(fn: Callable[..., list[SearchResult]]) -> SearchHandlerFn:
     """Wrap a (query, max_results, page) search fn into the (query, payload) interface."""
 
-    def _adapter(query: str, payload: dict[str, Any]) -> list[Any]:
+    def _adapter(query: str, payload: dict[str, Any]) -> list[SearchResult]:
         return fn(query, _max_results_from_payload(payload), _page_from_payload(payload))
 
     return _adapter
 
 
-def _make_gallica_adapter(fn: Callable[..., list[Any]]) -> SearchHandlerFn:
+def _make_gallica_adapter(fn: Callable[..., list[SearchResult]]) -> SearchHandlerFn:
     """Wrap the Gallica smart_search fn, forwarding gallica_type_filter from payload."""
 
-    def _adapter(query: str, payload: dict[str, Any]) -> list[Any]:
+    def _adapter(query: str, payload: dict[str, Any]) -> list[SearchResult]:
         return fn(
             query,
             max_records=_max_results_from_payload(payload),
@@ -366,14 +349,15 @@ def _make_gallica_adapter(fn: Callable[..., list[Any]]) -> SearchHandlerFn:
     return _adapter
 
 
-_search_handlers_cache: dict[str, SearchHandlerFn] | None = None
+_search_handlers_cache: types.MappingProxyType[str, SearchHandlerFn] | None = None
 
 
-def get_search_handlers() -> dict[str, SearchHandlerFn]:
+def get_search_handlers() -> types.MappingProxyType[str, SearchHandlerFn]:
     """Build the search-strategy dispatch dict from the provider registry.
 
     Search functions are lazy-imported from ``resolvers.discovery`` to avoid
     circular imports at module load time.  The result is cached after first call.
+    Returns a read-only mapping to prevent accidental mutation of the cache.
     """
     global _search_handlers_cache  # noqa: PLW0603
     if _search_handlers_cache is not None:
@@ -385,14 +369,23 @@ def get_search_handlers() -> dict[str, SearchHandlerFn]:
     for provider in PROVIDERS:
         if not provider.search_strategy or not provider.search_fn:
             continue
-        raw_fn = getattr(_disc, provider.search_fn)
+        raw_fn = getattr(_disc, provider.search_fn, None)
+        if raw_fn is None or not callable(raw_fn):
+            logger.warning(
+                "Provider %s declares search_fn=%r (strategy=%r) "
+                "but no matching callable found in resolvers.discovery — skipping",
+                provider.key,
+                provider.search_fn,
+                provider.search_strategy,
+            )
+            continue
         if provider.search_strategy == "gallica":
             handlers[provider.search_strategy] = _make_gallica_adapter(raw_fn)
         else:
             handlers[provider.search_strategy] = _make_standard_adapter(raw_fn)
 
-    _search_handlers_cache = handlers
-    return handlers
+    _search_handlers_cache = types.MappingProxyType(handlers)
+    return _search_handlers_cache
 
 
 __all__ = [

--- a/src/universal_iiif_core/resolvers/discovery.py
+++ b/src/universal_iiif_core/resolvers/discovery.py
@@ -13,20 +13,12 @@ import requests
 from ..config_manager import get_config_manager
 from ..discovery.contracts import ProviderResolution
 from ..discovery.orchestrator import resolve_provider_input as resolve_provider_input_orchestrated
-from ..discovery.search_adapters import build_search_strategy_handlers
 from ..exceptions import ResolverError
 from ..http_client import HTTPClient, get_http_client
 from ..logger import get_logger
-from ..providers import IIIFProvider
-from .archive_org import ArchiveOrgResolver
-from .cambridge import CambridgeResolver
-from .ecodices import EcodicesResolver
-from .gallica import GallicaResolver
-from .heidelberg import HeidelbergResolver
-from .institut import InstitutResolver
-from .loc import LOCResolver
+from ..providers import IIIFProvider, get_provider, get_search_handlers
+from .base import BaseResolver
 from .models import SearchResult
-from .oxford import OxfordResolver
 from .parsers import GallicaXMLParser, IIIFManifestParser
 from .registry import resolve_shelfmark as registry_resolve
 
@@ -186,7 +178,7 @@ def smart_search(
 
     # 1. TENTATIVO RISOLUZIONE DIRETTA (ID o LINK)
     # Usiamo il resolver Gallica specifico per catturare short ID (es. bpt6k...)
-    gallica_resolver = GallicaResolver()
+    gallica_resolver = get_provider("Gallica").resolver()
 
     # Se sembra un link/ID Gallica valido
     if gallica_resolver.can_resolve(text):
@@ -246,7 +238,7 @@ def _search_with_provider(
         return []
 
     payload = dict(filters or {})
-    handler = _SEARCH_STRATEGY_HANDLERS.get(provider.search_strategy or "")
+    handler = get_search_handlers().get(provider.search_strategy or "")
     if not handler:
         return []
     return handler(text, payload)
@@ -270,7 +262,7 @@ def resolve_provider_input(
         library,
         user_input,
         filters=filters,
-        search_handlers=_SEARCH_STRATEGY_HANDLERS,
+        search_handlers=get_search_handlers(),
         resolve_shelfmark_fn=resolve_shelfmark,
         search_with_provider_fn=_search_with_provider,
     )
@@ -307,7 +299,7 @@ def search_gallica_by_id(doc_id: str) -> list[SearchResult]:
         )
         resp.raise_for_status()
 
-        resolver = GallicaResolver()
+        resolver = get_provider("Gallica").resolver()
         return GallicaXMLParser.parse_sru(resp.content, resolver)
 
     except (requests.RequestException, xml.etree.ElementTree.ParseError, ValueError) as exc:
@@ -378,7 +370,7 @@ def search_gallica(
     fetch_records = 50 if normalized_filter != "all" else requested_records
     maximum_records = str(fetch_records)
     start_record = (max(1, page) - 1) * requested_records + 1
-    resolver = GallicaResolver()
+    resolver = get_provider("Gallica").resolver()
     params = {
         "operation": "searchRetrieve",
         "version": "1.2",
@@ -432,7 +424,7 @@ def search_institut(query: str, max_results: int = 20, page: int = 1) -> list[Se
     if not candidates:
         return []
 
-    resolver = InstitutResolver()
+    resolver = get_provider("Institut de France").resolver()
     results: list[SearchResult] = []
     for doc_id, fallback_title in candidates:
         if len(results) >= max_results:
@@ -473,7 +465,7 @@ def search_archive_org(query: str, max_results: int = 20, page: int = 1) -> list
         return []
 
     docs = payload.get("response", {}).get("docs", [])
-    resolver = ArchiveOrgResolver()
+    resolver = get_provider("Archive.org").resolver()
     results: list[SearchResult] = []
 
     for doc in docs:
@@ -516,7 +508,7 @@ def search_bodleian(query: str, max_results: int = 20, page: int = 1) -> list[Se
         return []
 
     members = payload.get("member", [])
-    resolver = OxfordResolver()
+    resolver = get_provider("Bodleian").resolver()
     results: list[SearchResult] = []
 
     for member in members:
@@ -556,7 +548,7 @@ def search_ecodices(query: str, max_results: int = 20, page: int = 1) -> list[Se
         logger.error("e-codices search failed for query '%s': %s", q, exc, exc_info=True)
         return []
 
-    resolver = EcodicesResolver()
+    resolver = get_provider("e-codices").resolver()
     results: list[SearchResult] = []
     for chunk in _ECODICES_RESULT_SPLIT_RE.split(response.text):
         if not chunk.strip():
@@ -575,7 +567,7 @@ def search_cambridge(query: str, max_results: int = 20, page: int = 1) -> list[S
         return []
 
     requested_results = max(1, min(max_results, 20))
-    resolver = CambridgeResolver()
+    resolver = get_provider("Cambridge").resolver()
     direct_manifest_url, direct_id = resolver.get_manifest_url(q)
     if direct_manifest_url and direct_id:
         return [
@@ -725,7 +717,7 @@ def search_loc(query: str, max_results: int = 20, page: int = 1) -> list[SearchR
         logger.error("LOC search failed for query '%s': empty/invalid payload", q)
         return []
 
-    resolver = LOCResolver()
+    resolver = get_provider("Library of Congress").resolver()
     results: list[SearchResult] = []
     for entry in payload.get("results", []):
         if not isinstance(entry, dict):
@@ -761,7 +753,7 @@ def search_heidelberg(query: str, max_results: int = 20, page: int = 1) -> list[
         return []
 
     requested_results = max(1, min(max_results, 20))
-    resolver = HeidelbergResolver()
+    resolver = get_provider("Heidelberg").resolver()
     direct_manifest_url, direct_id = resolver.get_manifest_url(q)
     if direct_manifest_url and direct_id:
         viewer_url = f"https://digi.ub.uni-heidelberg.de/diglit/{direct_id}"
@@ -883,9 +875,7 @@ def _extract_institut_candidates(html: str, max_results: int) -> list[tuple[str,
     return candidates
 
 
-def _fetch_institut_manifest_result(
-    doc_id: str, fallback_title: str, resolver: InstitutResolver
-) -> SearchResult | None:
+def _fetch_institut_manifest_result(doc_id: str, fallback_title: str, resolver: BaseResolver) -> SearchResult | None:
     manifest_url, _ = resolver.get_manifest_url(doc_id)
     if not manifest_url:
         return None
@@ -1181,7 +1171,7 @@ def _first_text(values: Any) -> str:
     return _clean_html_text(str(values or ""))
 
 
-def _build_bodleian_result(member: dict[str, Any], resolver: OxfordResolver) -> SearchResult | None:
+def _build_bodleian_result(member: dict[str, Any], resolver: BaseResolver) -> SearchResult | None:
     viewer_url = str(member.get("id") or "").strip()
     manifest_url = str(member.get("manifest", {}).get("id") or "").strip()
     _, doc_id = resolver.get_manifest_url(viewer_url)
@@ -1230,7 +1220,7 @@ def _first_bodleian_thumbnail(value: Any) -> str:
     return ""
 
 
-def _build_ecodices_result(chunk: str, resolver: EcodicesResolver) -> SearchResult | None:
+def _build_ecodices_result(chunk: str, resolver: BaseResolver) -> SearchResult | None:
     facsimile_match = _ECODICES_FACSIMILE_RE.search(chunk)
     if not facsimile_match:
         return None
@@ -1313,13 +1303,13 @@ def search_vatican(query: str, max_results: int = 5, page: int = 1) -> list[Sear
     Returns:
         List of SearchResult for manifests that exist
     """
-    from .vatican import VaticanResolver, normalize_shelfmark
+    from .vatican import normalize_shelfmark
 
     normalized_query = (query or "").strip()
     if not normalized_query:
         return []
 
-    resolver = VaticanResolver()
+    resolver = get_provider("Vaticana").resolver()
     results: list[SearchResult] = []
 
     _append_normalized_candidate(results, normalized_query, resolver, normalize_shelfmark, max_results)
@@ -1526,20 +1516,6 @@ def _verify_vatican_manifest(manifest_url: str, ms_id: str, resolver) -> SearchR
     except (requests.RequestException, requests.Timeout) as exc:
         logger.debug("Vatican manifest check failed for %s: %s", ms_id, exc)
         return None
-
-
-_SEARCH_STRATEGY_HANDLERS: Final[dict[str, Any]] = build_search_strategy_handlers(
-    smart_search_fn=smart_search,
-    search_vatican_fn=search_vatican,
-    search_institut_fn=search_institut,
-    search_archive_org_fn=search_archive_org,
-    search_bodleian_fn=search_bodleian,
-    search_ecodices_fn=search_ecodices,
-    search_cambridge_fn=search_cambridge,
-    search_harvard_fn=search_harvard,
-    search_loc_fn=search_loc,
-    search_heidelberg_fn=search_heidelberg,
-)
 
 
 __all__ = [

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,7 @@
 from universal_iiif_core.providers import (
+    PROVIDERS,
     get_provider,
+    get_search_handlers,
     is_known_provider,
     iter_providers,
     provider_library_options,
@@ -108,3 +110,24 @@ def test_resolve_with_provider_does_not_misclassify_archive_free_text():
     assert provider.key == "Unknown"
     assert doc_id is None
     assert manifest_url is None
+
+
+def test_get_search_handlers_returns_all_searchable_strategies():
+    """get_search_handlers must cover every provider that declares a search_strategy."""
+    handlers = get_search_handlers()
+    expected_keys = {p.search_strategy for p in PROVIDERS if p.search_strategy and p.search_fn}
+    assert set(handlers.keys()) == expected_keys
+
+
+def test_get_search_handlers_is_cached():
+    """Repeated calls must return the same dict instance (lazy-init caching)."""
+    assert get_search_handlers() is get_search_handlers()
+
+
+def test_provider_search_fn_matches_search_strategy():
+    """Every provider with a search_strategy must also declare search_fn."""
+    for provider in PROVIDERS:
+        if provider.search_strategy:
+            assert provider.search_fn is not None, (
+                f"Provider {provider.key} has search_strategy={provider.search_strategy!r} but no search_fn"
+            )


### PR DESCRIPTION
## Summary

Decouples the provider registry from direct resolver imports in `discovery.py`, centralizing provider lookup and search handler dispatch in `providers.py`.

## Changes

- Added `search_fn: str | None` field to `IIIFProvider` — each provider declares its search function name
- Created `get_search_handlers()` in `providers.py` — builds the dispatch dict via lazy import from `resolvers.discovery`, with caching
- `discovery.py` no longer imports resolver classes directly — uses `get_provider("X").resolver()` and `get_search_handlers()`
- Type hints of helper functions (`_build_bodleian_result`, `_build_ecodices_result`, `_fetch_institut_manifest_result`) changed from specific resolvers to `BaseResolver`
- `_SEARCH_STRATEGY_HANDLERS` removed from `discovery.py`
- `build_search_strategy_handlers` in `search_adapters.py` deprecated (docstring) but left functional for backward compat
- 3 new tests in `test_providers.py`: handler keys coverage, caching, search_fn/search_strategy consistency

## Files modified

- `src/universal_iiif_core/providers.py`
- `src/universal_iiif_core/resolvers/discovery.py`
- `src/universal_iiif_core/discovery/search_adapters.py`
- `tests/test_providers.py`

## Testing

All tests pass (400 passed, 5 skipped). No regressions.

Closes #104