### PR TITLE
docs: refresh English docs and wiki publishing flow

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           python scripts/check_docs_language.py
 
+      - name: Check docs integrity
+        run: |
+          python scripts/check_docs_integrity.py
+
       - name: Check changelog policy
         run: |
           python scripts/check_changelog_policy.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to this project are documented in this file.
   ([#141](https://github.com/nikazzio/universal-iiif-studio/pull/141),
   [`0c437d2`](https://github.com/nikazzio/universal-iiif-studio/commit/0c437d22321db0cdc6e07ac43c89b28672c81392))
 
-- Decompose studio_handlers.py into _studio/ subpackage (Phase 1)
+- Decompose `studio_handlers.py` into `_studio/` subpackage (Phase 1)
   ([#141](https://github.com/nikazzio/universal-iiif-studio/pull/141),
   [`0c437d2`](https://github.com/nikazzio/universal-iiif-studio/commit/0c437d22321db0cdc6e07ac43c89b28672c81392))
 

--- a/README.md
+++ b/README.md
@@ -1,152 +1,128 @@
-# Universal IIIF Downloader & Studio
-
 <p align="center">
-  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/ci.yml?branch=main&style=for-the-badge&label=CI"></a>
-  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/docs-ci.yml"><img alt="Docs CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/docs-ci.yml?branch=main&style=for-the-badge&label=Docs"></a>
-  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/wiki-sync.yml"><img alt="Wiki Sync" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/wiki-sync.yml?branch=main&style=for-the-badge&label=Wiki"></a>
-  <a href="https://www.python.org/"><img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-0f172a?style=for-the-badge&logo=python&logoColor=white"></a>
-  <a href="https://docs.astral.sh/ruff/"><img alt="Ruff" src="https://img.shields.io/badge/Lint-Ruff-1d4ed8?style=for-the-badge&logo=ruff&logoColor=white"></a>
-  <a href="https://github.com/nikazzio/universal-iiif-studio/releases"><img alt="Release" src="https://img.shields.io/github/v/release/nikazzio/universal-iiif-studio?display_name=tag&style=for-the-badge"></a>
-  <a href="LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-0b7285?style=for-the-badge"></a>
+  <img src="assets/header.svg" alt="Scriptoria" width="100%">
 </p>
 
 <p align="center">
-  <img
-    src="https://capsule-render.vercel.app/api?type=soft&color=0:0f172a,35:1d4ed8,70:0b7285,100:99f6e4&height=220&section=header&text=UNIVERSAL%20IIIF%20STUDIO&fontSize=52&fontColor=ffffff&animation=fadeIn&desc=Discovery%20%E2%80%A2%20Library%20%E2%80%A2%20Studio%20%E2%80%A2%20Output&descSize=20&descAlignY=68"
-    alt="Universal IIIF Studio capsule header"
-    width="100%"
-  >
+  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/ci.yml?branch=main&label=CI&style=flat-square"></a>
+  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/docs-ci.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/docs-ci.yml?branch=main&label=Docs&style=flat-square"></a>
+  <a href="https://www.python.org/"><img alt="Python 3.10+" src="https://img.shields.io/badge/python-3.10+-3572A5?style=flat-square&logo=python&logoColor=white"></a>
+  <a href="https://github.com/nikazzio/universal-iiif-studio/releases"><img alt="Release" src="https://img.shields.io/github/v/release/nikazzio/universal-iiif-studio?display_name=tag&style=flat-square&color=0b7285"></a>
+  <a href="LICENSE"><img alt="MIT" src="https://img.shields.io/badge/license-MIT-22d3ee?style=flat-square"></a>
 </p>
 
 <p align="center">
-  <pre>
-██╗   ██╗███╗   ██╗██╗██╗   ██╗███████╗██████╗ ███████╗ █████╗ ██╗
-██║   ██║████╗  ██║██║██║   ██║██╔════╝██╔══██╗██╔════╝██╔══██╗██║
-██║   ██║██╔██╗ ██║██║██║   ██║█████╗  ██████╔╝███████╗███████║██║
-██║   ██║██║╚██╗██║██║╚██╗ ██╔╝██╔══╝  ██╔══██╗╚════██║██╔══██║██║
-╚██████╔╝██║ ╚████║██║ ╚████╔╝ ███████╗██║  ██║███████║██║  ██║███████╗
- ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝
-  </pre>
+  <em>A research workbench for IIIF manuscripts — discover, download, study, export.</em>
 </p>
 
-Download IIIF material, keep local working copies under control, and move from discovery to study to export without leaving one toolchain.
+---
 
-## Why This Project
+> **Web** &nbsp;`iiif-studio` → [127.0.0.1:8000](http://127.0.0.1:8000) &emsp;·&emsp;
+> **CLI** &nbsp;`iiif-cli "<manifest-url>"`
 
-Universal IIIF Downloader & Studio combines two workflows that are usually split apart:
-
-- `iiif-studio` for Discovery, Library, Studio, and PDF export.
-- `iiif-cli` for direct manifest-driven downloads and scripting.
-- Shared provider resolution, storage, and configuration for both entrypoints.
-
-The project is optimized for manuscript-heavy research workflows where you need fast iteration, reproducible local storage, and enough control over remote IIIF servers to avoid brittle ad-hoc tooling.
-
-```mermaid
-flowchart LR
-    A[Discovery] --> B[Library]
-    B --> C[Studio]
-    C --> D[Output]
-    D --> E[PDF Export]
-
-    A -. resolve/search .-> X[(Provider Registry)]
-    B -. local assets .-> Y[(Vault + Downloads)]
-    C -. manifests/scans .-> Y
-    E -. profiles/cache/jobs .-> Y
-```
+<!-- TODO: add real screenshots
+<p align="center">
+  <img src="assets/screenshot-discovery.png" width="32%" alt="Discovery">
+  <img src="assets/screenshot-studio.png" width="32%" alt="Studio">
+  <img src="assets/screenshot-export.png" width="32%" alt="Export">
+</p>
+-->
 
 ## Quickstart
 
 ```bash
 git clone https://github.com/nikazzio/universal-iiif-studio.git
 cd universal-iiif-studio
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 iiif-studio
 ```
 
-Open `http://127.0.0.1:8000`.
+## How It Works
 
-CLI smoke test:
+```mermaid
+flowchart LR
+    A[🔍 Discovery] --> B[📚 Library]
+    B --> C[📖 Studio]
+    C --> D[📤 Output]
+
+    A -. search/resolve .-> R[(Provider Registry)]
+    B -. local assets .-> V[(Vault)]
+    C -. manifests .-> V
+    D -. export jobs .-> V
+```
+
+| Tab | What it does |
+|-----|-------------|
+| **Discovery** | Resolve URLs, IDs, shelfmarks. Search 10+ IIIF libraries. |
+| **Library** | Browse and manage your local manuscript collection. |
+| **Studio** | Document workspace — Mirador viewer, OCR transcription, page actions. |
+| **Output** | PDF inventory, thumbnail-level actions, export job queue. |
+
+## Key Features
+
+- **10+ IIIF providers** — Vatican, Gallica, Harvard, Bodleian, Heidelberg, LoC, Archive.org, Cambridge, e-codices, Institut
+- **Provider registry** — shared resolution for web UI and CLI
+- **PDF export profiles** — local and remote high-res modes with quality presets
+- **Centralized HTTP** — retries, exponential backoff, per-library network policies
+- **Local-first workflow** — reproducible storage, no cloud dependencies
+
+## CLI
 
 ```bash
 iiif-cli "https://digi.vatlib.it/iiif/MSS_Urb.lat.1779/manifest.json"
 ```
 
-## Feature Highlights
+Any IIIF-compliant manifest URL works directly.
 
-- Shared provider registry for web and CLI resolution.
-- Search adapters for major IIIF sources plus direct manifest handling.
-- Local-first study workflow with Library, Studio workspace, and Output tab.
-- Remote preview vs local-only viewing modes in Mirador.
-- PDF profile system with local and temporary remote high-resolution export modes.
-- Centralized HTTP client with retries, backoff, and per-library policies.
+## Documentation
 
-## Run Modes
+| | |
+|---|---|
+| 📘 [User Guide](docs/DOCUMENTAZIONE.md) | 🏗️ [Architecture](docs/ARCHITECTURE.md) |
+| ⚙️ [Config Reference](docs/CONFIG_REFERENCE.md) | 🌐 [HTTP Client](docs/HTTP_CLIENT.md) |
+| 📖 [Wiki](docs/wiki/Home.md) | 🗂️ [All Docs](docs/index.md) |
 
-### Web Studio
-
-```bash
-iiif-studio
-```
-
-Alternative entrypoint:
+## Development
 
 ```bash
-python3 src/studio_app.py
+pytest tests/                    # tests
+ruff check . --fix               # lint
+ruff format .                    # format
+ruff check . --select C901       # complexity
 ```
-
-### CLI
-
-```bash
-iiif-cli "<manifest-url>"
-```
-
-## Documentation Map
-
-- [Documentation Hub](docs/index.md)
-- [User Guide](docs/DOCUMENTAZIONE.md)
-- [Architecture](docs/ARCHITECTURE.md)
-- [Configuration Reference](docs/CONFIG_REFERENCE.md)
-- [HTTP Client Notes](docs/HTTP_CLIENT.md)
-- [Wiki Maintenance](docs/WIKI_MAINTENANCE.md)
-- [GitHub Wiki Source](docs/wiki/Home.md)
-
-## Current Product Shape
-
-- `Discovery` resolves URLs, IDs, shelfmarks, and provider-specific free-text search.
-- `Library` is the canonical entrypoint for local items.
-- `Studio` opens a document workspace and falls back to a recent-work hub when no item is selected.
-- `Output` handles PDF inventory, thumbnail-level page actions, and export jobs.
 
 ## Troubleshooting
 
-`iiif-studio: command not found`
+<details>
+<summary><code>iiif-studio: command not found</code></summary>
 
 ```bash
-source .venv/bin/activate
-pip install -e .
+source .venv/bin/activate && pip install -e .
 ```
+</details>
 
-`ruff: command not found`
+<details>
+<summary><code>ruff: command not found</code></summary>
 
 ```bash
-source .venv/bin/activate
-pip install -r requirements-dev.txt
+source .venv/bin/activate && pip install -r requirements-dev.txt
 ```
+</details>
 
-Port `8000` already in use:
+<details>
+<summary>Port 8000 already in use</summary>
 
-- Stop the conflicting process and start `iiif-studio` again.
+Stop the conflicting process and restart `iiif-studio`.
+</details>
 
-Studio opens without a document:
+<details>
+<summary>Studio opens without a document</summary>
 
-- Expected behavior. Open an item from `Library`, or resume from the recent-work hub at `/studio`.
+Expected. Open an item from Library, or use the recent-work hub at `/studio`.
+</details>
 
-## Development Commands
+---
 
-```bash
-pytest tests/
-ruff check . --select C901
-ruff format .
-```
+<p align="center">
+  <sub>Built for manuscript-heavy research workflows · <a href="LICENSE">MIT</a></sub>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
 # Universal IIIF Downloader & Studio
 
-[![CI](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml/badge.svg)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml)
-[![Release](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/release.yml/badge.svg)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/release.yml)
-[![Python](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Lint: Ruff](https://img.shields.io/badge/lint-ruff-46a2f1?logo=ruff&logoColor=white)](https://docs.astral.sh/ruff/)
+[![CI](https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml)
+[![Docs CI](https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/docs-ci.yml?branch=main&style=for-the-badge&label=Docs)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/docs-ci.yml)
+[![Wiki Sync](https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/wiki-sync.yml?branch=main&style=for-the-badge&label=Wiki)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/wiki-sync.yml)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-0f172a?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
+[![License](https://img.shields.io/badge/License-MIT-0b7285?style=for-the-badge)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/nikazzio/universal-iiif-studio?display_name=tag&style=for-the-badge)](https://github.com/nikazzio/universal-iiif-studio/releases)
 
-Developer-focused toolkit for downloading IIIF manuscripts and working with them via:
-- a FastHTML/HTMX web studio (`iiif-studio`)
-- a command-line interface (`iiif-cli`)
+![Universal IIIF Downloader & Studio hero](docs/assets/readme-hero.svg)
+
+Download IIIF material, keep local working copies under control, and move from discovery to study to export without leaving one toolchain.
+
+## Why This Project
+
+Universal IIIF Downloader & Studio combines two workflows that are usually split apart:
+
+- `iiif-studio` for Discovery, Library, Studio, and PDF export.
+- `iiif-cli` for direct manifest-driven downloads and scripting.
+- Shared provider resolution, storage, and configuration for both entrypoints.
+
+The project is optimized for manuscript-heavy research workflows where you need fast iteration, reproducible local storage, and enough control over remote IIIF servers to avoid brittle ad-hoc tooling.
+
+```mermaid
+flowchart LR
+    A[Discovery] --> B[Library]
+    B --> C[Studio]
+    C --> D[Output]
+    D --> E[PDF Export]
+
+    A -. resolve/search .-> X[(Provider Registry)]
+    B -. local assets .-> Y[(Vault + Downloads)]
+    C -. manifests/scans .-> Y
+    E -. profiles/cache/jobs .-> Y
+```
 
 ## Quickstart
 
@@ -21,32 +45,22 @@ pip install -e .
 iiif-studio
 ```
 
-Open: `http://127.0.0.1:8000`
+Open `http://127.0.0.1:8000`.
 
-Smoke test CLI:
+CLI smoke test:
 
 ```bash
 iiif-cli "https://digi.vatlib.it/iiif/MSS_Urb.lat.1779/manifest.json"
 ```
 
-## Features
+## Feature Highlights
 
-- IIIF manifest resolution and page download pipeline
-- **Centralized HTTP client** with automatic retry, exponential backoff, and per-host rate limiting
-- Discovery with shared provider registry for web + CLI
-- Discovery with free-text search plus provider-specific filters (currently Gallica type filter with labels `Tutti i materiali`, `Solo manoscritti`, `Solo libri a stampa`)
-- Discovery internals split into typed orchestrator/search adapters (`universal_iiif_core.discovery`) and modular UI components (`studio_ui.components.discovery_*`)
-- **Configurable search results**: `settings.discovery.max_results_per_provider` (default 20, editable from Settings > Discovery tab)
-- **Async manifest probing**: Archive.org results appear immediately; manifest validity is checked per-card via HTMX lazy-load
-- **Load-more pagination**: paginatable providers (Archive.org, Harvard, LOC, Gallica) support "Carica altri risultati" for additional pages
-- Native PDF-first workflow (configurable)
-- Canvas/image fallback with optional compiled PDF generation
-- Local Library + Studio workflow: select in Library, analyze in Studio
-- Studio Output tab with PDF profiles, source-mode selection (`Locale` / `Remoto temporaneo`) and job monitor
-- **Mirador dual viewing modes**: remote preview for incomplete downloads, local-only for offline work
-- Thumbnail-level page controls in Studio Output (`Hi`, `Std`, `Opt`) with resolution transparency (`Locale`, `Remote`, verified-direct indicator)
-- Professional status panel with color-coded technical indicators
-- `src/` package layout with separated `core`, `ui`, and `cli` modules
+- Shared provider registry for web and CLI resolution.
+- Search adapters for major IIIF sources plus direct manifest handling.
+- Local-first study workflow with Library, Studio workspace, and Output tab.
+- Remote preview vs local-only viewing modes in Mirador.
+- PDF profile system with local and temporary remote high-resolution export modes.
+- Centralized HTTP client with retries, backoff, and per-library policies.
 
 ## Run Modes
 
@@ -62,188 +76,57 @@ Alternative entrypoint:
 python3 src/studio_app.py
 ```
 
-Navigation model:
-- `Discovery` supports free text/shelfmark/ID/URL search and provider-specific filters when available.
-- `Aggiungi item` in Discovery performs a light prefetch (`metadata.json` + `manifest.json`) without full scans.
-- `Library` is the canonical entrypoint for local documents.
-- `Studio` is a document workspace (`/studio?doc_id=...&library=...`).
-- `Export` is a dedicated hub for batch/single exports (`/export`).
-- In Studio, the right tab is now `Output` (renamed from `Export`).
-- `/studio` without context opens the `Riprendi lavoro` recent hub (server-side persisted contexts).
-
 ### CLI
 
 ```bash
 iiif-cli "<manifest-url>"
 ```
 
-Direct resolution is shared across web and CLI for these providers:
-- Vaticana
-- Gallica
-- Institut de France
-- Bodleian
-- Heidelberg
-- Cambridge
-- e-codices
-- Harvard
-- Library of Congress
-- Internet Archive
+## Documentation Map
 
-Current discovery search coverage:
-- `search_first`: Gallica, Internet Archive
-- `fallback`: Vaticana, Institut de France
-- `direct + search adapter`: Bodleian, e-codices, Heidelberg, Cambridge, Harvard, Library of Congress
-- `direct only`: generic direct manifest URLs
+- [Documentation Hub](docs/index.md)
+- [User Guide](docs/DOCUMENTAZIONE.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Configuration Reference](docs/CONFIG_REFERENCE.md)
+- [HTTP Client Notes](docs/HTTP_CLIENT.md)
+- [Wiki Maintenance](docs/WIKI_MAINTENANCE.md)
+- [GitHub Wiki Source](docs/wiki/Home.md)
 
-Provider behavior summary:
+## Current Product Shape
 
-| Provider | Direct resolution | Free-text search | Notes |
-| --- | --- | --- | --- |
-| Vaticana | Yes | Yes | Hybrid flow: shelfmark heuristics first, DigiVatLib manuscripts search fallback for free text |
-| Gallica | Yes | Yes | Uses SRU search and optional type filter |
-| Institut de France | Yes | Yes | HTML search + manifest enrichment |
-| Bodleian | Yes | Yes | JSON-LD search surface |
-| Heidelberg | Yes | Yes (browser handoff when needed) | Direct ID/URL works; also normalizes inputs like `Cod. Pal. germ. 123` -> `cpg123`; generic queries can degrade to browser handoff |
-| Cambridge | Yes | Yes (browser handoff when blocked) | Signature/URL resolution works directly; blocked free-text queries return a browser handoff result that opens CUDL search |
-| e-codices | Yes | Yes | HTML search surface |
-| Harvard | Yes | Yes (hybrid) | Shows all catalog results; records without IIIF manifest are marked as consultazione online only |
-| Library of Congress | Yes | Yes | JSON API search; live manifest fetch may still be host-blocked in some environments |
-| Internet Archive | Yes | Yes | `advancedsearch.php` + IIIF manifest validation |
-| Altro / URL Diretto | Yes | No | Generic direct manifest resolution |
+- `Discovery` resolves URLs, IDs, shelfmarks, and provider-specific free-text search.
+- `Library` is the canonical entrypoint for local items.
+- `Studio` opens a document workspace and falls back to a recent-work hub when no item is selected.
+- `Output` handles PDF inventory, thumbnail-level page actions, and export jobs.
 
-Search result contract:
-- discovery providers return canonical `SearchResult` items with `manifest`, `library`, `id`, and optional `manifest_status`
-- `manifest_status` can be `"ok"`, `"pending"`, or `"unavailable"` — Archive.org results start as `"pending"` and are validated asynchronously via HTMX probe
-- providers should populate `viewer_url` when they know the source viewer URL
-- `raw` is still available for provider-specific metadata, but UI code should not depend on `raw["viewer_url"]` anymore
+## Troubleshooting
 
-## Configuration
+`iiif-studio: command not found`
 
-Runtime configuration is read from `config.json` through `universal_iiif_core.config_manager`.
-
-Key PDF settings:
-
-```json
-{
-  "settings": {
-    "images": {
-      "download_strategy_mode": "balanced",
-      "download_strategy_custom": ["3000", "1740", "max"],
-      "iiif_quality": "default"
-    },
-    "pdf": {
-      "viewer_dpi": 150,
-      "viewer_jpeg_quality": 95,
-      "prefer_native_pdf": true,
-      "create_pdf_from_images": false,
-      "profiles": {
-        "default": "balanced"
-      }
-    }
-  }
-}
+```bash
+source .venv/bin/activate
+pip install -e .
 ```
 
-Meaning:
-- `prefer_native_pdf`: if manifest `rendering` contains a native PDF, native flow is attempted first
-- `create_pdf_from_images`: when native PDF is not used, build a PDF from downloaded images only if `true`
-- `viewer_dpi`: DPI used when extracting JPG pages from native PDF for the web viewer
-- `viewer_jpeg_quality`: JPEG quality used only when rasterizing a native PDF into local scans
-- `images.download_strategy_mode`: preset ordering for direct IIIF attempts before stitch fallback (`balanced|quality_first|fast|archival|custom`)
-- `images.download_strategy_custom`: size list used when `mode=custom`; it is an ordered attempt list, not a “quality ranking”
-- `images.stitch_mode_default`: fallback policy for the standard downloader (`auto_fallback|direct_only|stitch_only`)
-- `images.iiif_quality`: IIIF quality segment in image URLs (recommended `default`)
-- `images.local_optimize.max_long_edge_px`: in-place optimization max edge for local scans
-- `images.local_optimize.jpeg_quality`: in-place optimization JPEG quality for local scans
-- `pdf.profiles.default`: default export profile (`balanced`, `high_quality`, `archival_highres`, `lightweight`)
-- `pdf.profiles.catalog.<profile>.max_parallel_page_fetch`: parallel fetch cap for remote high-res temp exports
-- `storage.partial_promotion_mode`: controls if validated staged pages are promoted from temp to scans (`never|on_pause`)
-- `storage.remote_cache.max_bytes|retention_hours|max_items`: persistent remote-resolution cache limits (Studio Output)
-- `viewer.mirador.require_complete_local_images`: when `true`, Studio viewer is gated until local page availability is complete (set to `false` or use `?allow_remote_preview=true` URL parameter to enable remote preview mode)
-- `viewer.source_policy.saved_mode`: policy for `saved` items in Studio (`remote_first|local_first`)
-- `network.global.*`: global HTTP transport settings (timeout, retries, max concurrent jobs)
-- `network.libraries.<library>.*`: per-library network policies for rate limiting and backoff (e.g., Gallica has stricter limits: 4 req/min)
-- PDF profiles are created/edited in `Settings > PDF Export`; item Output tab selects a profile per job
+`ruff: command not found`
 
-## Output Layout
+```bash
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+```
 
-For each manuscript:
-- `downloads/<Library>/<DocumentId>/scans/`: page images (`pag_XXXX.jpg`)
-- `downloads/<Library>/<DocumentId>/pdf/`: native and/or compiled PDF outputs
-- `downloads/<Library>/<DocumentId>/data/`: metadata and processing JSON artifacts
-- `data/local/temp_images/<DocumentId>/`: staging area for validated pages before final promotion to `scans/`
+Port `8000` already in use:
 
-Prefetch-light behavior:
-- `Aggiungi item` creates/updates `downloads/<Library>/<DocumentId>/data/metadata.json` and `manifest.json`.
-- Full page images are not downloaded until explicit `download_full`/`start_download`.
+- Stop the conflicting process and start `iiif-studio` again.
 
-All runtime paths are resolved via `ConfigManager`.
+Studio opens without a document:
 
-Download staging behavior:
-- runtime validates pages in `temp_images/<DocumentId>` and promotes to `scans/` when completeness gates are satisfied.
-- segmented/retry runs are supported: previously staged validated pages are counted together with current-run pages.
-- optional pause-time promotion is controlled by `settings.storage.partial_promotion_mode`.
-- with `on_pause`, staged pages are promoted when a running job is paused; existing scans are overwritten only for explicit refresh/redownload flows.
-- Studio page actions (`Hi`/`Std`) can overwrite a single local scan immediately without waiting for full-manuscript completeness.
+- Expected behavior. Open an item from `Library`, or resume from the recent-work hub at `/studio`.
 
-## Dev Commands
+## Development Commands
 
 ```bash
 pytest tests/
 ruff check . --select C901
 ruff format .
 ```
-
-## Troubleshooting
-
-`iiif-studio: command not found`
-- Ensure virtualenv is active and reinstall editable package:
-  ```bash
-  source .venv/bin/activate
-  pip install -e .
-  ```
-
-`ruff: command not found`
-- Install dev dependencies:
-  ```bash
-  pip install -r requirements-dev.txt
-  ```
-
-`Address already in use` on startup
-- Port `8000` is already in use. Stop the conflicting process, then rerun `iiif-studio`.
-
-Studio loads but pages are missing
-- Check `downloads/<Library>/<DocumentId>/scans/` for `pag_XXXX.jpg` files.
-- Check `data/local/temp_images/<DocumentId>/` for staged pages.
-- If pages are intentionally kept staged, use `settings.storage.partial_promotion_mode=on_pause` to promote on pause.
-- Verify `config.json` PDF flags (`prefer_native_pdf`, `create_pdf_from_images`).
-- For incomplete downloads, use `?allow_remote_preview=true` URL parameter to view all pages via remote preview mode (Mirador fetches images on-demand from original server).
-
-Mirador viewer shows "remote" or no images for incomplete download
-- **Expected behavior**: By default (`viewer.mirador.require_complete_local_images=true`), Studio gates the viewer until all pages are downloaded locally.
-- **Remote preview mode**: Add `?allow_remote_preview=true` to the Studio URL to enable remote mode, where Mirador loads the original manifest and fetches images on-demand from the library server.
-- **Local-only mode**: Once download is complete, Studio automatically switches to local mode using only downloaded images (works offline).
-- See `docs/wiki/Studio-Workflow.md` for detailed explanation of viewing modes.
-
-No results in Discovery for a known Gallica title
-- Keep the `Gallica` filter on `All materials` for broad lookup.
-- Use `Manuscripts` or `Printed books` only when you want to narrow down result type.
-
-`/studio` opens the recent hub instead of the editor
-- Expected behavior: without `doc_id` + `library`, Studio shows `Riprendi lavoro`.
-- Open a document from Library via "Apri Studio", or use "Riprendi ultimo" in `/studio`.
-
-`config.json` changes not applied
-- Validate JSON shape under `settings`.
-- Restart the running process.
-- Compare with `config.example.json`.
-
-## Documentation
-
-- User/feature guide: `docs/DOCUMENTAZIONE.md`
-- Architecture: `docs/ARCHITECTURE.md`
-- HTTP Client implementation: `docs/HTTP_CLIENT.md`
-- Config reference (single source for `config.json` keys): `docs/CONFIG_REFERENCE.md`
-- Wiki maintenance model and sync workflow: `docs/WIKI_MAINTENANCE.md`
-- Issue triage and governance policy: `docs/ISSUE_TRIAGE_POLICY.md`
-- Contributor/agent rules: `AGENTS.md`

--- a/README.md
+++ b/README.md
@@ -11,22 +11,23 @@
 </p>
 
 <p align="center">
-  <img src="docs/assets/readme-hero.svg" alt="Universal IIIF Downloader &amp; Studio hero" width="1200">
+  <img
+    src="https://capsule-render.vercel.app/api?type=soft&color=0:0f172a,35:1d4ed8,70:0b7285,100:99f6e4&height=220&section=header&text=UNIVERSAL%20IIIF%20STUDIO&fontSize=52&fontColor=ffffff&animation=fadeIn&desc=Discovery%20%E2%80%A2%20Library%20%E2%80%A2%20Studio%20%E2%80%A2%20Output&descSize=20&descAlignY=68"
+    alt="Universal IIIF Studio capsule header"
+    width="100%"
+  >
 </p>
 
-```text
- _   _       _                          _   ___ ___ ___ _____
-| | | |_ __ (_)_   _____ _ __ ___  __ _| | |_ _|_ _|_ _|  ___|
-| | | | '_ \| \ \ / / _ \ '__/ __|/ _` | |  | | | | | || |_
-| |_| | | | | |\ V /  __/ |  \__ \ (_| | |  | | | | | ||  _|
- \___/|_| |_|_| \_/ \___|_|  |___/\__,_|_| |___|___|___|_|
-
- ____                      _                 _              _ _
-|  _ \  _____      ___ __ | | ___   __ _  __| | ___ _ __   | (_)_ __   ___ _ __
-| | | |/ _ \ \ /\ / / '_ \| |/ _ \ / _` |/ _` |/ _ \ '__|  | | | '_ \ / _ \ '__|
-| |_| | (_) \ V  V /| | | | | (_) | (_| | (_| |  __/ |     | | | | | |  __/ |
-|____/ \___/ \_/\_/ |_| |_|_|\___/ \__,_|\__,_|\___|_|     |_|_|_| |_|\___|_|
-```
+<p align="center">
+  <pre>
+██╗   ██╗███╗   ██╗██╗██╗   ██╗███████╗██████╗ ███████╗ █████╗ ██╗
+██║   ██║████╗  ██║██║██║   ██║██╔════╝██╔══██╗██╔════╝██╔══██╗██║
+██║   ██║██╔██╗ ██║██║██║   ██║█████╗  ██████╔╝███████╗███████║██║
+██║   ██║██║╚██╗██║██║╚██╗ ██╔╝██╔══╝  ██╔══██╗╚════██║██╔══██║██║
+╚██████╔╝██║ ╚████║██║ ╚████╔╝ ███████╗██║  ██║███████║██║  ██║███████╗
+ ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝
+  </pre>
+</p>
 
 Download IIIF material, keep local working copies under control, and move from discovery to study to export without leaving one toolchain.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 # Universal IIIF Downloader & Studio
 
-[![CI](https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml)
-[![Docs CI](https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/docs-ci.yml?branch=main&style=for-the-badge&label=Docs)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/docs-ci.yml)
-[![Wiki Sync](https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/wiki-sync.yml?branch=main&style=for-the-badge&label=Wiki)](https://github.com/nikazzio/universal-iiif-studio/actions/workflows/wiki-sync.yml)
-[![Python](https://img.shields.io/badge/Python-3.10%2B-0f172a?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
-[![License](https://img.shields.io/badge/License-MIT-0b7285?style=for-the-badge)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/nikazzio/universal-iiif-studio?display_name=tag&style=for-the-badge)](https://github.com/nikazzio/universal-iiif-studio/releases)
+<p align="center">
+  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/ci.yml?branch=main&style=for-the-badge&label=CI"></a>
+  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/docs-ci.yml"><img alt="Docs CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/docs-ci.yml?branch=main&style=for-the-badge&label=Docs"></a>
+  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/wiki-sync.yml"><img alt="Wiki Sync" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/wiki-sync.yml?branch=main&style=for-the-badge&label=Wiki"></a>
+  <a href="https://www.python.org/"><img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-0f172a?style=for-the-badge&logo=python&logoColor=white"></a>
+  <a href="https://docs.astral.sh/ruff/"><img alt="Ruff" src="https://img.shields.io/badge/Lint-Ruff-1d4ed8?style=for-the-badge&logo=ruff&logoColor=white"></a>
+  <a href="https://github.com/nikazzio/universal-iiif-studio/releases"><img alt="Release" src="https://img.shields.io/github/v/release/nikazzio/universal-iiif-studio?display_name=tag&style=for-the-badge"></a>
+  <a href="LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-0b7285?style=for-the-badge"></a>
+</p>
 
-![Universal IIIF Downloader & Studio hero](docs/assets/readme-hero.svg)
+<p align="center">
+  <img src="docs/assets/readme-hero.svg" alt="Universal IIIF Downloader &amp; Studio hero" width="1200">
+</p>
+
+```text
+ _   _       _                          _   ___ ___ ___ _____
+| | | |_ __ (_)_   _____ _ __ ___  __ _| | |_ _|_ _|_ _|  ___|
+| | | | '_ \| \ \ / / _ \ '__/ __|/ _` | |  | | | | | || |_
+| |_| | | | | |\ V /  __/ |  \__ \ (_| | |  | | | | | ||  _|
+ \___/|_| |_|_| \_/ \___|_|  |___/\__,_|_| |___|___|___|_|
+
+ ____                      _                 _              _ _
+|  _ \  _____      ___ __ | | ___   __ _  __| | ___ _ __   | (_)_ __   ___ _ __
+| | | |/ _ \ \ /\ / / '_ \| |/ _ \ / _` |/ _` |/ _ \ '__|  | | | '_ \ / _ \ '__|
+| |_| | (_) \ V  V /| | | | | (_) | (_| | (_| |  __/ |     | | | | | |  __/ |
+|____/ \___/ \_/\_/ |_| |_|_|\___/ \__,_|\__,_|\___|_|     |_|_|_| |_|\___|_|
+```
 
 Download IIIF material, keep local working copies under control, and move from discovery to study to export without leaving one toolchain.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flowchart LR
 ```
 
 | Tab | What it does |
-|-----|-------------|
+| --- | --- |
 | **Discovery** | Resolve URLs, IDs, shelfmarks. Search 10+ IIIF libraries. |
 | **Library** | Browse and manage your local manuscript collection. |
 | **Studio** | Document workspace — Mirador viewer, OCR transcription, page actions. |
@@ -77,7 +77,7 @@ Any IIIF-compliant manifest URL works directly.
 ## Documentation
 
 | | |
-|---|---|
+| --- | --- |
 | 📘 [User Guide](docs/DOCUMENTAZIONE.md) | 🏗️ [Architecture](docs/ARCHITECTURE.md) |
 | ⚙️ [Config Reference](docs/CONFIG_REFERENCE.md) | 🌐 [HTTP Client](docs/HTTP_CLIENT.md) |
 | 📖 [Wiki](docs/wiki/Home.md) | 🗂️ [All Docs](docs/index.md) |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <em>A research workbench for IIIF manuscripts — discover, download, study, export.</em>
+  <strong>Scriptoria</strong> — a research workbench for IIIF manuscripts.
 </p>
 
 ---

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="800" y2="200" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="50%" stop-color="#0e4d6e"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="50%" stop-color="#67e8f9"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
+    </linearGradient>
+    <linearGradient id="text-fill" x1="0" y1="80" x2="0" y2="130" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#e0f2fe"/>
+      <stop offset="100%" stop-color="#7dd3fc"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="200" rx="16" fill="url(#bg)"/>
+
+  <!-- Subtle top accent line -->
+  <rect x="100" y="0" width="600" height="1.5" rx="1" fill="url(#accent)" opacity="0.6"/>
+
+  <!-- Decorative corner marks -->
+  <path d="M 30 30 L 30 15 L 45 15" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
+  <path d="M 770 30 L 770 15 L 755 15" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
+  <path d="M 30 170 L 30 185 L 45 185" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
+  <path d="M 770 170 L 770 185 L 755 185" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
+
+  <!-- Main title -->
+  <text x="400" y="105" text-anchor="middle" font-family="'Segoe UI', 'SF Pro Display', system-ui, sans-serif" font-size="58" font-weight="300" letter-spacing="12" fill="url(#text-fill)">SCRIPTORIA</text>
+
+  <!-- Subtitle -->
+  <text x="400" y="145" text-anchor="middle" font-family="'SF Mono', 'Cascadia Code', 'JetBrains Mono', monospace" font-size="13" letter-spacing="6" fill="#67e8f9" opacity="0.7">DISCOVERY · LIBRARY · STUDIO · OUTPUT</text>
+
+  <!-- Bottom accent line -->
+  <rect x="100" y="198.5" width="600" height="1.5" rx="1" fill="url(#accent)" opacity="0.6"/>
+</svg>

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,39 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 621 196" fill="none">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="800" y2="200" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#0e4d6e"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <linearGradient id="bg-grad" x1="0" y1="0" x2="621" y2="196" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0a0f1a"/>
+      <stop offset="50%" stop-color="#0c1929"/>
+      <stop offset="100%" stop-color="#0a0f1a"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="800" y2="0" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#22d3ee"/>
+    <linearGradient id="cyan-grad" x1="0" y1="0" x2="621" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="30%" stop-color="#22d3ee"/>
       <stop offset="50%" stop-color="#67e8f9"/>
-      <stop offset="100%" stop-color="#22d3ee"/>
+      <stop offset="70%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
     </linearGradient>
-    <linearGradient id="text-fill" x1="0" y1="80" x2="0" y2="130" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#e0f2fe"/>
-      <stop offset="100%" stop-color="#7dd3fc"/>
+    <linearGradient id="border-grad" x1="0" y1="0" x2="621" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/>
+      <stop offset="20%" stop-color="#22d3ee" stop-opacity="0.4"/>
+      <stop offset="50%" stop-color="#67e8f9" stop-opacity="0.6"/>
+      <stop offset="80%" stop-color="#22d3ee" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
     </linearGradient>
   </defs>
 
   <!-- Background -->
-  <rect width="800" height="200" rx="16" fill="url(#bg)"/>
+  <rect width="621" height="196" rx="12" fill="url(#bg-grad)"/>
+  
+  <!-- Subtle border glow -->
+  <rect x="0.5" y="0.5" width="620" height="195" rx="12" fill="none" stroke="url(#border-grad)" stroke-width="1"/>
 
-  <!-- Subtle top accent line -->
-  <rect x="100" y="0" width="600" height="1.5" rx="1" fill="url(#accent)" opacity="0.6"/>
+  <!-- Top accent line -->
+  <rect x="93.14999999999999" y="0" width="434.7" height="1" fill="url(#border-grad)"/>
 
-  <!-- Decorative corner marks -->
-  <path d="M 30 30 L 30 15 L 45 15" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
-  <path d="M 770 30 L 770 15 L 755 15" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
-  <path d="M 30 170 L 30 185 L 45 185" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
-  <path d="M 770 170 L 770 185 L 755 185" stroke="#22d3ee" stroke-width="1.5" fill="none" opacity="0.4"/>
-
-  <!-- Main title -->
-  <text x="400" y="105" text-anchor="middle" font-family="'Segoe UI', 'SF Pro Display', system-ui, sans-serif" font-size="58" font-weight="300" letter-spacing="12" fill="url(#text-fill)">SCRIPTORIA</text>
-
-  <!-- Subtitle -->
-  <text x="400" y="145" text-anchor="middle" font-family="'SF Mono', 'Cascadia Code', 'JetBrains Mono', monospace" font-size="13" letter-spacing="6" fill="#67e8f9" opacity="0.7">DISCOVERY · LIBRARY · STUDIO · OUTPUT</text>
+  <!-- ASCII art text -->
+  <text x="40" y="44" font-family="'JetBrains Mono', 'Cascadia Code', 'SF Mono', 'Fira Code', Consolas, monospace" font-size="11" fill="url(#cyan-grad)" xml:space="preserve"> ███████╗  ██████╗ ██████╗  ██╗ ██████╗  ████████╗  ██████╗  ██████╗  ██╗  █████╗ </text>
+  <text x="40" y="60" font-family="'JetBrains Mono', 'Cascadia Code', 'SF Mono', 'Fira Code', Consolas, monospace" font-size="11" fill="url(#cyan-grad)" xml:space="preserve"> ██╔════╝ ██╔════╝ ██╔══██╗ ██║ ██╔══██╗ ╚══██╔══╝ ██╔═══██╗ ██╔══██╗ ██║ ██╔══██╗</text>
+  <text x="40" y="76" font-family="'JetBrains Mono', 'Cascadia Code', 'SF Mono', 'Fira Code', Consolas, monospace" font-size="11" fill="url(#cyan-grad)" xml:space="preserve"> ███████╗ ██║      ██████╔╝ ██║ ██████╔╝    ██║    ██║   ██║ ██████╔╝ ██║ ███████║</text>
+  <text x="40" y="92" font-family="'JetBrains Mono', 'Cascadia Code', 'SF Mono', 'Fira Code', Consolas, monospace" font-size="11" fill="url(#cyan-grad)" xml:space="preserve"> ╚════██║ ██║      ██╔══██╗ ██║ ██╔═══╝     ██║    ██║   ██║ ██╔══██╗ ██║ ██╔══██║</text>
+  <text x="40" y="108" font-family="'JetBrains Mono', 'Cascadia Code', 'SF Mono', 'Fira Code', Consolas, monospace" font-size="11" fill="url(#cyan-grad)" xml:space="preserve"> ███████║ ╚██████╗ ██║  ██║ ██║ ██║         ██║    ╚██████╔╝ ██║  ██║ ██║ ██║  ██║</text>
+  <text x="40" y="124" font-family="'JetBrains Mono', 'Cascadia Code', 'SF Mono', 'Fira Code', Consolas, monospace" font-size="11" fill="url(#cyan-grad)" xml:space="preserve"> ╚══════╝  ╚═════╝ ╚═╝  ╚═╝ ╚═╝ ╚═╝         ╚═╝     ╚═════╝  ╚═╝  ╚═╝ ╚═╝ ╚═╝  ╚═╝</text>
+  <text x="310.5" y="164" text-anchor="middle" font-family="'SF Pro Display', 'Segoe UI', system-ui, sans-serif" font-size="14" letter-spacing="4" fill="#67e8f9" opacity="0.65">discover · download · study · export</text>
 
   <!-- Bottom accent line -->
-  <rect x="100" y="198.5" width="600" height="1.5" rx="1" fill="url(#accent)" opacity="0.6"/>
+  <rect x="93.14999999999999" y="195" width="434.7" height="1" fill="url(#border-grad)"/>
 </svg>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,162 +1,147 @@
-# 🏗️ Project Architecture
+# Project Architecture
 
 ## Overview
 
-Universal IIIF Downloader & Studio separates a **FastHTML/htmx-based UI shell** (`studio_ui/`) from the pure Python core (`universal_iiif_core/`). The UI renders HTML elements, wires HTMX for asynchronous swaps, and embeds Mirador, while the back-end keeps all metadata, storage, OCR logic, and network resolution untouchable.
+Universal IIIF Downloader & Studio separates a Python UI shell from reusable core services:
 
-## System Layers
+- `studio_ui/` renders the FastHTML and HTMX interface.
+- `universal_iiif_core/` owns provider resolution, storage, download orchestration, export logic, OCR services, and runtime policy.
+- `universal_iiif_cli/` exposes the CLI entrypoint on top of the same core services.
 
-The application is strictly divided into two main layers. The **UI Layer** depends on the **Core Layer**, never the other way around.
+The UI depends on the core layer. The core layer does not depend on UI modules.
 
-### 1. Presentation Layer (`studio_ui/`)
+## Current UI Structure
 
-* **Pages**: Layout builders (`studio_layout`, Mirador wiring).
-* **Components**: Reusable UI parts (tab sets, toast holder, SimpleMDE-powered editor, Mirador viewer, snippet cards, professional status panel).
-* **Routes**:
-  * `studio_handlers.py`: Logic-heavy handlers for the editor, viewer, and OCR operations. Implements Mirador local/remote mode selection.
-  * `discovery_handlers.py`: Route entrypoints for search/add/download flows, delegating persistence helpers to `discovery_persistence.py`.
-  * `library_handlers.py`: Local Assets listing, cleanup, retry, and deletion actions.
-  * `library_query.py`: Shared filtering/query/view-model helpers for Library routes.
-* **Common**: Shared utilities (`build_toast`, htmx triggers, Mirador window presets).
-* **Status Panel**: Color-coded badges for technical status (read_source: AMBER for remote, GREEN for local; state, scans, staging, PDF info).
+The Studio-facing UI is now organized as focused packages rather than large single-file modules.
 
-### 2. Core Business Logic (`universal_iiif_core/`)
+### Routes And Workspace Helpers
 
-* **Discovery Module**:
-  * **Provider Registry**: A shared provider catalog drives web Discovery, settings options, and CLI direct resolution from the same metadata source.
-  * **Orchestrator package**: `universal_iiif_core.discovery` now owns typed contracts and orchestration policy (`contracts.py`, `orchestrator.py`) plus search strategy adapter mapping (`search_adapters.py`).
-  * **Resolvers**: Direct resolution still ends in provider-specific resolver classes, but registration happens through the provider registry rather than UI/CLI hardcoding.
-  * **Search Modes**: Each provider declares `search_mode` (`direct`, `fallback`, `search_first`) plus an optional `search_strategy`. This keeps the UX consistent while allowing provider-specific search adapters.
-  * **Search Coverage**: Current searchable providers are `Gallica`, `Vaticana`, `Institut de France`, `Internet Archive`, `Bodleian`, `e-codices`, `Cambridge`, `Heidelberg`, `Harvard`, and `Library of Congress`, but some adapters are intentionally hybrid. For example Cambridge and Heidelberg free-text can degrade to browser handoff results when the public site blocks scripted search or does not expose stable machine-readable hits.
-  * **Result Contract**: Provider adapters return canonical `SearchResult` payloads. `viewer_url` is the normalized field for source viewer links; `manifest_status` tracks async validation state (`ok`, `pending`, `unavailable`); `raw` remains available only for provider-specific extras.
-  * **Pagination**: Search adapters thread `max_results` (configurable, default 20) and `page` from the request payload through to provider functions. Providers with paginated APIs (Archive.org, LOC, Harvard, Gallica) support real server-side pagination via a "load more" HTMX flow. Non-paginatable providers (Vatican, Bodleian, Cambridge, Heidelberg, Institut, e-codices) accept the parameters but ignore `page`.
-  * **Async Manifest Probing**: Archive.org results are returned immediately with `manifest_status="pending"`. A dedicated `POST /api/discovery/probe_manifest` endpoint validates each manifest per-card via HTMX lazy-load, avoiding blocking the search response on slow IIIF servers.
-* **Downloader Logic**:
-  * Implements the **Golden Flow** (Native PDF check -> Extraction -> Fallback to IIIF).
-  * Manages threading and DB updates.
-  * Uses staged local pages in `temp_images/<doc_id>` before promoting validated files into `scans/`.
-  * Split across `logic/downloader.py` (orchestrator), `logic/downloader_pdf.py` (PDF/native pipeline), and `logic/downloader_runtime.py` (canvas/runtime pipeline).
-* **Network Layer (`utils.py`)**:
-  * Provides a resilient `requests.Session`.
-  * Handles WAF Bypass (Browser User-Agents, Dynamic Brotli).
-* **HTTP Client (`http_client.py`)**:
-  * Centralized HTTP client with automatic retry, exponential backoff, and per-host rate limiting.
-  * Per-library network policies (timeout, concurrency, backoff, rate limits).
-  * Metrics tracking for requests, retries, and timeouts.
-  * Sliding window rate limiter prevents overwhelming library servers (Gallica: 4 req/min, others: 20 req/min).
-  * Used by: downloader, IIIF tiles, resolution probing, manifest fetching, external catalog scraping.
-* **OCR Module**:
-  * Abstracts differences between local Kraken models and Cloud APIs (OpenAI/Anthropic).
-* **Storage**:
-  * `VaultManager`: SQLite interface for metadata and job tracking (`queued/running/partial/complete` states).
-  * `vault_snippets.py` and `vault_jobs.py` hold extracted repository-style methods attached to `VaultManager`.
+- `studio_ui/routes/studio.py` registers the Studio routes.
+- `studio_ui/routes/studio_handlers.py` acts as the public handler surface and orchestration entrypoint.
+- `studio_ui/routes/_studio/` contains focused helpers for:
+  - workspace context;
+  - manifest and read-source selection;
+  - thumbnail/export fragments;
+  - page-level job preferences;
+  - UI utility glue.
 
----
+This keeps the route surface stable while moving implementation detail into narrower modules.
 
-## Interactive Flows
+### Settings UI
 
-### 1. Discovery, Library Add, and Resolution
+- `studio_ui/components/settings/panes/` contains domain-specific settings panes.
+- The package is organized by responsibility such as general, images, network, PDF, system, viewer, and discovery settings.
 
-1. **User Input**: The user enters free text, shelfmark (e.g., "Urb.lat.1779"), an ID, or a URL.
-2. **Provider Lookup**: Discovery resolves the selected library through the shared provider registry.
-3. **Provider Resolution**: The provider decides whether to try direct resolution first, search first, or direct resolution with search fallback.
-4. **Normalization**: Provider resolvers convert "dirty" inputs into canonical IIIF Manifest URLs only when `can_resolve()` positively identifies the input as direct.
-5. **Search Adapter Stage**: `max_results` and `page` are read from config/payload. Optional provider-specific filters (e.g. Gallica type filter) are applied before invoking the search adapter.
-6. **Preview / Result List**: Search adapters return canonical `SearchResult` entries; direct resolution fetches manifest details for preview and lazy-checks native PDF availability. Results without a `manifest` are rendered as consult-only cards. Archive.org results with `manifest_status="pending"` are validated asynchronously via HTMX probe.
-7. **Load More**: For paginatable providers, a "Carica altri risultati" button at the bottom of the result list fetches the next page via `POST /api/discovery/load_more`.
-8. **Action Split**: From each result, the user can either add to local Library (`saved`) or add + enqueue download.
+### Studio Output UI
 
-### 2. Download Manager + Golden Flow
+- `studio_ui/components/studio/export/` owns the Output tab assembly.
+- The package is split into:
+  - PDF inventory rendering;
+  - page actions;
+  - thumbnail rendering;
+  - output tab assembly;
+  - client-side tab script generation.
 
-Downloads are queued in a DB-backed manager with bounded concurrency (`settings.network.global.max_concurrent_download_jobs`).
-Queued jobs are promoted FIFO (with optional prioritization) and each running worker follows this flow:
+## Core Services
 
-1. **Check Native PDF**: Does the manifest provide a download link?
-    * **YES + `settings.pdf.prefer_native_pdf=true`**: Download the PDF. Then, **EXTRACT** pages to high-quality JPGs in `scans/` (Critical for Studio compatibility).
-    * **NO**: Fallback to downloading IIIF tiles/canvases one by one into staging (`temp_images/<doc_id>`), then promote validated pages into `scans/`.
-2. **Optional Compiled PDF**: If (and only if) no native PDF was used **AND** `settings.pdf.create_pdf_from_images=true`, generate a PDF from the downloaded images.
-3. **Completion**: Update DB status and manuscript `asset_state` (`complete` or `partial`).
-4. **Segmented Resume Safety**: Retry/range runs count already-staged validated pages together with current-run pages before promotion, so partial batches converge without deadlock.
+### Discovery
 
-### 3. Studio & OCR
+Discovery uses a shared provider registry and typed orchestration in `universal_iiif_core.discovery`.
 
-0. **Entry Point**: Library is the canonical selector; `/studio` without `doc_id/library` renders the Studio recent hub (`Riprendi lavoro`) using server-side persisted contexts.
-1. **Async Request**: Clicking "Run OCR" sends an HTMX POST to `/api/run_ocr_async`.
-2. **Job State**: The server spawns a thread and tracks progress in `ocr_state.py`.
-3. **Polling**: The UI shows an overlay that polls `/api/check_ocr_status` every 2 seconds.
-4. **Completion**: Text is saved to `transcription.json` and the History table.
+Responsibilities:
 
-### 4. Mirador Viewing Modes
+- classify user input;
+- resolve direct provider inputs;
+- route free-text search to provider search adapters;
+- normalize results into the shared search contract;
+- support provider-specific filters and pagination where available.
 
-Studio supports **two distinct viewing modes** for the Mirador viewer, automatically selected based on download completeness:
+### Downloading
 
-* **REMOTE MODE** (for incomplete/paused downloads):
-  - Mirador loads the **original manifest** from the library server (e.g., `gallica.bnf.fr`).
-  - Displays **ALL pages** by fetching images on-demand from the remote server.
-  - Useful for previewing documents before full download completes.
-  - Requires internet connection.
-  - User can force this mode with `?allow_remote_preview=true` URL parameter.
+Download orchestration is handled by core services and a job manager backed by local state.
 
-* **LOCAL MODE** (for completed downloads):
-  - Mirador loads the **local manifest** (`/iiif/manifest/...`) served by Studio.
-  - Displays **only downloaded pages** using local images from `scans/`.
-  - Works completely offline.
-  - Default mode when `viewer.mirador.require_complete_local_images=true` (default) and all pages are available locally.
+Runtime behavior includes:
 
-**Mode Selection Logic** (`studio_handlers.py`):
-- `_resolve_studio_read_source_mode()`: Determines if local images are sufficient or remote preview is needed.
-- `_select_studio_manifest_url()`: Returns appropriate manifest URL (local or remote) based on mode.
-- Config setting: `viewer.mirador.require_complete_local_images` (default: `true`) gates local viewer until download completes.
-- User override: `?allow_remote_preview=true` URL parameter forces remote mode regardless of settings.
+- native PDF-first strategy when configured;
+- IIIF image fallback;
+- staged page validation before promotion;
+- resume and retry safety across partial runs.
 
----
+### Storage
 
-## UI & Configuration Details
+`VaultManager` and related storage modules keep track of:
 
-* **Viewer Config**: The `config.json` (`settings.viewer`) section directly controls Mirador's behavior (Zoom levels, viewing modes) and the Visual Tab's default image filters.
-* **Mirador Modes**: Automatic switching between remote preview (incomplete downloads) and local-only (complete downloads) based on `viewer.mirador.require_complete_local_images` setting.
-* **State Persistence**:
-  * **Server-side**: SQLite (`vault.db`) and JSON files (`data/local/`).
-  * **Client-side**: Sidebar state (collapsed/expanded) is saved in `localStorage`.
-* **Visual Feedback**:
-  * **Toasts**: Floating notifications anchored to the top-right viewport.
-  * **Progress**: Real-time queue/running status driven by DB polling in the Download Manager side panel.
-  * **Studio page jobs**: per-page `Hi/Std` actions are stored as `studio_export_page` jobs and rendered in Discovery as a compact auxiliary section, not as full document download cards.
-  * **Status Panel**: Professional color-coded badges for technical status (read_source, state, scans, staging, PDF info).
+- manuscripts and metadata;
+- download and export jobs;
+- UI preferences and local working state;
+- snippet and OCR-related local records.
 
-## Key Design Decisions
+### Export
 
-1. **Scans as Operational Source + Temp Staging**: `scans/` is the operational source for Viewer/OCR/Cropper, but runtime can stage validated pages in `temp_images/<doc_id>` before promotion. Promotion policy can stay strict (`never`) or happen on pause (`settings.storage.partial_promotion_mode=on_pause`), with overwrite of existing scans enabled only for explicit refresh/redownload flows.
-2. **Zero Legacy**: Deprecated APIs are removed or stubbed. All legacy HTTP shims (`get_request_session`, `get_json`) have been retired from `utils.py`; the deprecated `config.py` tripwire module has been deleted. All HTTP calls now go through `HTTPClient` (singleton via `get_http_client()`).
-3. **Network Resilience**: The system assumes library servers are hostile (rate limits, firewalls) and uses aggressive retry logic, header mimicking, and centralized HTTP client with per-host rate limiting.
-4. **Pure HTTP Front-end**: No heavy client-side frameworks (React/Vue). The UI logic is driven by Python via FastHTML and HTMX.
-5. **Studio PR3 route scope (decision log, 2026-03-05)**: do not add dedicated `/studio/partial/viewer` and `/studio/partial/availability` routes for now. Keep viewer gating and availability in the main `/studio` flow to avoid route surface growth and duplicated state logic. Re-evaluate only if measured UI payload/latency or independent refresh requirements justify a split.
-6. **Centralized HTTP Client (Issue #71, 2026-03-09; completed #107, 2026-03-27)**: Eliminated ~200+ lines of duplicate retry/backoff logic by introducing `HTTPClient` class with automatic retry, exponential backoff, per-host rate limiting, and metrics. All core IIIF modules and discovery provider search surfaces now use this client. The only remaining raw `requests.Session` usage is the Vatican search flow, which requires an isolated cookie session.
-7. **Current Discovery Refactor Boundary (2026-03-14)**: discovery orchestration and search adapter dispatch are now extracted in `universal_iiif_core.discovery`, and UI rendering is split into dedicated modules (`discovery_form`, `discovery_results`, `discovery_download_panel`, `discovery_page`) with a compatibility aggregator. Remaining technical debt is mostly inside provider-specific parser/search code still hosted in `universal_iiif_core.resolvers.discovery`.
+Export services manage:
 
-## Local Data & Cleanup
+- PDF inventory discovery;
+- profile-driven export jobs;
+- local and temporary remote high-resolution image sourcing;
+- cleanup and retention policies.
 
-- Runtime directories (`downloads/`, `data/local/*`, `logs/`, `temp_images/`) are resolved via `universal_iiif_core.config_manager` and treated as regenerable data. Do not store config assets or secrets in these directories.
-- `scripts/clean_user_data.py` uses the manager to resolve paths and supports `--dry-run`, `--yes`, `--include-data-local`, and `--extra` while preserving `config.json`.
-- For full build/test/debug cycles, clean runtime data first (recommended: `--dry-run`, then `--yes`, `pytest tests/`, `ruff check . --select C901`, `ruff format .`) and register new runtime paths in `.gitignore`.
+### OCR
 
-## Engineering Rationale and Governance
+OCR services abstract local and remote engines behind a common workflow, while the UI handles asynchronous job feedback.
 
-This section centralizes design rationale that is intentionally excluded from `AGENTS.md`.
+### Networking
 
-1. **`src/`-only source layout**
-   - Keeps import behavior explicit and avoids root-level script drift.
-   - Reduces ambiguity between package code and tooling scripts.
-2. **ConfigManager as single runtime path/config authority**
-   - Prevents path fragmentation and hidden assumptions in handlers/services.
-   - Ensures local/user data locations are environment-resolved consistently.
-3. **Scans-first runtime model**
-   - `scans/` remains the operational source for viewer, OCR, and crop tools.
-   - `temp_images/<doc_id>` is a staging layer for validated pages and segmented retries.
-   - Native PDF support is an ingestion strategy, not a runtime storage replacement.
-4. **Complexity ceiling (C901 <= 10)**
-   - Enforces decomposition into testable single-purpose helpers.
-   - Reduces regression risk in flow-heavy services (download, OCR, resolvers).
-5. **Procedural policy split**
-   - `AGENTS.md`: procedural rules and required command flows only.
-   - `docs/ARCHITECTURE.md`: rationale, tradeoffs, and system-level decisions.
+The centralized HTTP client is the primary transport layer for runtime network operations.
+
+Responsibilities:
+
+- retry and backoff policy;
+- per-library network customization;
+- concurrency and rate limiting;
+- metrics and request hygiene around hostile or fragile upstream services.
+
+## End-To-End Flow
+
+### 1. Discovery To Library
+
+1. The user submits a URL, identifier, shelfmark, or query.
+2. Discovery resolves or searches through the provider registry.
+3. Results are normalized into the shared search contract.
+4. `Add item` writes local metadata without forcing a full download.
+
+### 2. Download To Local Working State
+
+1. A download job starts through the job manager.
+2. The runtime prefers native PDF when available and configured.
+3. Otherwise it downloads IIIF images and validates them in staging.
+4. Validated output is promoted into local scans when the promotion policy allows it.
+
+### 3. Library To Studio
+
+1. The user opens a local item from Library.
+2. Studio builds a workspace context from local records and manifest state.
+3. The viewer chooses remote or local mode based on completeness and policy.
+4. The user works across transcription, history, metadata, image actions, and output.
+
+### 4. Output And Export
+
+1. The Output tab reads current PDF inventory.
+2. The user selects an export profile or uses a page-level refresh action.
+3. Export jobs run through the storage-backed job system.
+4. Output artifacts are persisted under runtime-managed paths.
+
+## Design Rules
+
+1. `docs/` is the documentation source of truth; wiki pages are derived publish targets.
+2. Runtime paths are resolved through `ConfigManager`, not hardcoded strings.
+3. `scans/` is the operational image source for local study workflows.
+4. Staging and retry behavior must remain safe for partial and resumed downloads.
+5. UI package structure should reflect responsibility boundaries, not just file size limits.
+
+## Current Hotspots For Contributors
+
+- Discovery orchestration and provider search behavior.
+- Studio workspace and read-source selection.
+- Output tab assembly and thumbnail/page-action rendering.
+- Settings panes for network, PDF, viewer, and system behavior.
+- Config reference and runtime validation alignment.

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -93,6 +93,8 @@ Global network settings used by the centralized `HTTPClient` for all HTTP operat
   - Read timeout for HTTP responses (used by HTTPClient)
 - `settings.network.global.transport_retries` (`int`, default: `3`)
   - Transport-level retries for HTTP adapter
+- `settings.network.global.per_host_concurrency` (`int`, default: `4`)
+  - Default per-host concurrency used when library-specific policy does not override it
 
 **Note**: These settings apply to ALL libraries and cannot be overridden per-library. For per-library customization, use `settings.network.libraries.<library>.*` fields.
 

--- a/docs/DOCUMENTAZIONE.md
+++ b/docs/DOCUMENTAZIONE.md
@@ -1,330 +1,176 @@
-# 📘 Universal IIIF Downloader & Studio – Guida Completa
-
-## 1. Introduzione
-
-Universal IIIF Downloader & Studio è una piattaforma modulare per lo studio di materiali IIIF (manoscritti e libri a stampa).
-L'architettura separa nettamente il backend (Python core) dall'interfaccia (FastHTML/HTMX).
-L'esperienza utente è quella di una SPA (Single Page Application): `Libreria` è il punto di accesso ai documenti locali e `Studio` è il workspace con Mirador a sinistra e pannelli operativi (Trascrizione, Snippets, History, Visual) a destra.
-
-## 2. Configurazione Dettagliata (`config.json`)
-
-Il file `config.json` è la singola fonte di verità.
-
-### ⚙️ Sistema e Download
-
-Parametri **sempre globali** (valgono per tutte le biblioteche):
-* `settings.network.global.max_concurrent_download_jobs`: Numero massimo di download documento in esecuzione contemporanea (default: 2). Gli altri job restano in coda.
-* `settings.network.global.connect_timeout_s`: timeout apertura connessione HTTP.
-* `settings.network.global.read_timeout_s`: timeout lettura risposta HTTP.
-* `settings.network.global.transport_retries`: retry trasporto lato client HTTP.
-
-Parametri **override per biblioteca** (attivi solo con `settings.network.libraries.<lib>.use_custom_policy=true`):
-* `workers_per_job`, `min_delay_s`, `max_delay_s`, `retry_max_attempts`, `backoff_base_s`, `backoff_cap_s`, `respect_retry_after`.
-
-* `settings.images.tile_stitch_max_ram_gb`: Limite RAM per l'assemblaggio di immagini IIIF giganti (Tile Stitching).
-* `settings.images.probe_remote_max_resolution`: mantiene il probing `info.json` usato dalla riga informativa `Remote` nelle miniature Studio; non cambia la strategia di download.
-* `settings.images.download_strategy_mode`: Preset operativo (`balanced`, `quality_first`, `fast`, `archival`, `custom`) che definisce l'ordine dei tentativi diretti IIIF prima dell'eventuale stitch.
-* `settings.images.download_strategy_custom`: Strategia custom (lista size, es. `3000,1740,max`) usata solo quando `mode=custom`. E un ordine di tentativi, non una classifica assoluta di qualità.
-* `settings.images.stitch_mode_default`: decide se il download standard puo fare fallback automatico a stitch (`auto_fallback`), restare solo diretto (`direct_only`) o usare solo stitch (`stitch_only`).
-* `settings.images.iiif_quality`: Segmento quality nelle URL IIIF (`.../quality.jpg`). In generale lasciare `default`; usare `gray/bitonal` solo per casi specifici.
-* `settings.images.local_optimize.max_long_edge_px`: lato lungo massimo usato da `Ottimizza scans locali`.
-* `settings.images.local_optimize.jpeg_quality`: qualità JPEG usata da `Ottimizza scans locali`.
-
-### 📄 Opzioni PDF (Core + UI Config)
-
-* `settings.pdf.prefer_native_pdf` (default: `true`): se il manifest IIIF espone un PDF nativo (`rendering`), il downloader lo usa come sorgente primaria.
-* `settings.pdf.create_pdf_from_images` (default: `false`): se non viene usato un PDF nativo, crea un PDF compilato dalle immagini scaricate.
-* `settings.pdf.viewer_dpi` (default: `150`): DPI usati per estrarre le immagini JPG dal PDF nativo per il viewer.
-* `settings.pdf.viewer_jpeg_quality` (default: `95`): qualità JPEG usata solo nella rasterizzazione dei PDF nativi in scans locali.
-* `settings.pdf.profiles`: catalogo preset PDF avanzati (`balanced`, `high_quality`, `archival_highres`, `lightweight`) con supporto custom globale.
-* `settings.pdf.profiles.catalog.<profilo>.image_source_mode`: definisce la sorgente immagini del profilo (`local_balanced`, `local_highres`, `remote_highres_temp`).
-* `settings.pdf.profiles.catalog.<profilo>.max_parallel_page_fetch`: limite di fetch parallelo quando il profilo usa il remoto high-res temporaneo.
-* `settings.storage.highres_temp_retention_hours`: retention dei file high-res temporanei usati per export avanzati.
-* `settings.storage.exports_retention_days`: retention globale degli export PDF salvati.
-* `settings.storage.thumbnails_retention_days`: retention della cache miniature usata nel tab Output.
-* `settings.storage.auto_prune_on_startup`: se attivo, applica pruning retention all'avvio (export + temp high-res).
-* `settings.storage.partial_promotion_mode`: gestione promozione pagine validate da `temp_images` a `scans` (`never` oppure `on_pause`).
-* `settings.storage.remote_cache.max_bytes`, `retention_hours`, `max_items`: limiti cache persistente risoluzioni remote.
-* `settings.viewer.source_policy.saved_mode`: policy sorgente Studio per item `saved` (`remote_first|local_first`).
-
-Nel pannello **Settings > PDF Export** trovi i controlli con help text esplicativi:
-* sub-tab **Predefiniti e copertina**:
-  - **Prefer Native PDF**: priorita al PDF della biblioteca se disponibile.
-  - **Create PDF from Images**: attiva/disattiva la generazione del PDF compilato in fallback.
-  - **PDF Viewer DPI**: qualità estrazione da PDF nativo.
-  - **Default PDF Profile**: preset operativo globale.
-  - metadati copertina (logo, curatore, descrizione) e default formato/compressione.
-* sub-tab **Catalogo Profili**:
-  - selettore unico profili con voce `Nuovo profilo...` per creare preset custom;
-  - editor completo del profilo (cover/colophon, compression, source mode, lato lungo max, JPEG quality, parallel fetch);
-  - toggle **Imposta come default globale**;
-  - pulsante rosso **Elimina Profilo**;
-  - dopo create/delete/update la pagina viene ricaricata per riallineare subito il catalogo disponibile in Output.
+# User Guide
 
-Nel pannello **Settings > Viewer**:
-* sub-tab **Zoom**, **Defaults**, **Presets** per separare parametri OpenSeadragon e filtri visivi.
-
-Nel pannello **Settings > Paths & System**:
-* sub-tab **Paths & Logging** per directory runtime e logging base;
-* sub-tab **Storage & Security** per retention, pruning, test live e CORS.
+Universal IIIF Downloader & Studio supports a single working flow:
 
-Nel tab **Studio > Output**:
-* in alto visualizzi sempre l'inventario PDF locale gia presente per il documento;
-* usi i sub-tab `Crea PDF` / `Pagine` / `Job` per separare configurazione, visualizzazione miniature e monitoraggio coda;
-* nel sub-tab `Crea PDF` il blocco principale e:
-  - **Profilo PDF** + pulsante **Gestisci profili** nella stessa riga;
-  - pannello override a scomparsa (**Personalizza override per questo job**) da aprire solo quando serve.
-* il pulsante finale **Crea PDF** usa:
-  - il profilo selezionato;
-  - eventuali override compilati nel pannello espanso;
-  - lo scope selezionato (`Tutte le pagine` oppure `Solo selezione`).
-* nel sub-tab `Pagine`:
-  - la griglia miniature mostra per ogni pagina **Locale** e **Remote**; se una dimensione diretta è stata verificata da un download reale, compare un pallino verde accanto a `Locale`;
-  - azione puntuale **Hi** per forzare un refresh diretto `full/max` della singola pagina;
-  - azione puntuale **Std** per usare la stessa strategia standard del volume (tentativi diretti + stitch solo come fallback);
-  - pulsante **Ottimizza scans locali** per ridurre lo spazio occupato dalle scans locali con ottimizzazione lossy (resize + compressione JPEG configurabile via `settings.images.local_optimize.max_long_edge_px` e `settings.images.local_optimize.jpeg_quality`).
-    - **Nota di sicurezza**: l'ottimizzazione valida tutti i percorsi file per prevenire attacchi di path traversal via symlink. Solo i file all'interno della directory downloads vengono processati.
+1. Find or resolve an item in `Discovery`.
+2. Save or download it into `Library`.
+3. Open it in `Studio`.
+4. Export PDFs or refresh single pages from `Output`.
 
-### 🤖 Motori OCR
+This guide describes the current product behavior as implemented now.
 
-Le API key vanno in `api_keys`: `openai`, `anthropic`, `google_vision`, `huggingface`.
+## Core Navigation
 
-* `settings.ocr.ocr_engine`: Seleziona il motore attivo (es. `"openai"` o `"kraken"`).
-* `settings.ocr.kraken_enabled`: abilita l'uso esplicito del backend Kraken quando selezionato.
+- `Discovery` resolves direct inputs and provider-backed search.
+- `Library` is the canonical entrypoint for local items.
+- `Studio` is the document workspace.
+- `Output` is the export surface inside Studio.
+- `/studio` without `doc_id` and `library` opens the recent-work hub.
 
-### 🎨 Preferenze UI
+## Discovery
 
-* `settings.ui.theme_color`: Colore d’accento per l'interfaccia.
-* `settings.ui.toast_duration`: Durata in ms delle notifiche a scomparsa.
+Discovery accepts:
 
-## 3. Discovery e Download (Novità v0.7)
+- direct manifest URLs;
+- provider item URLs;
+- shelfmarks or IDs supported by a provider;
+- free-text queries for providers with search adapters.
 
-Il sistema di download è stato completamente riscritto per essere intelligente e resiliente.
+Current behavior:
 
-### 🔌 HTTP Client Centralizzato (v0.7.0)
+- `Add item` performs a lightweight prefetch and saves local metadata.
+- Full image download does not start until the user explicitly starts a download.
+- Search results use canonical fields such as `manifest`, `library`, `id`, and optional `manifest_status`.
+- Providers with real pagination expose `Load more` in the result list.
 
-Il nuovo `HTTPClient` centralizzato elimina oltre 200 righe di codice duplicato per retry e backoff:
-* **Retry automatico** con backoff esponenziale configurabile per biblioteca.
-* **Rate limiting per host** con algoritmo sliding window (Gallica: 4 req/min, altre: 20 req/min).
-* **Policy di rete per biblioteca** con timeout, concurrency e backoff personalizzabili.
-* **Metriche di tracciamento** (richieste, retry, timeout).
-* **Thread-safe** con semafori per limitare richieste parallele per host.
+## Library
 
-Moduli migrati: downloader, IIIF tiles, resolution probe, manifest fetch, catalogo esterno.
+Library is the local asset catalog for saved and downloaded material.
 
-Config chiavi: `settings.network.global.*` (globale) e `settings.network.libraries.<library>.*` (per-biblioteca).
+Typical actions:
 
-### 🧭 Discovery separata da Download Manager
+- open an item in Studio;
+- review local or partial status;
+- retry missing pages;
+- clean partial data;
+- remove an item and related runtime state.
 
-La pagina Discovery è divisa in due aree:
-* **Sinistra**: ricerca/risoluzione manifest e anteprime.
-* **Destra**: **Download Manager** con coda, job in esecuzione, errori e retry.
-* I job pagina generati da `Hi` / `Std` nello Studio non sporcano più la lista principale: vengono mostrati in una sezione compatta separata (`Attività Immagini Studio`) con solo testo e azione `Annulla` o `Rimuovi`.
+Local runtime data is stored under the paths resolved by `ConfigManager`, not by hardcoded directory assumptions.
 
-Questo permette di continuare a cercare nuovi manoscritti mentre uno o più download sono in corso.
+## Studio
 
-Prefetch light:
-* `Aggiungi item` salva entry DB + `metadata.json` + `manifest.json` locali.
-* non avvia il download completo delle scansioni.
+Studio combines the document viewer and operational panels for transcription, history, visual inspection, metadata, images, and output.
 
-### 🔎 Ricerca libera + filtri opzionali
+### Recent-work Hub
 
-La barra di ricerca Discovery è pensata in stile "standard":
-* campo testo ampio (supporta query lunghe, segnature, ID, URL);
-* select biblioteca;
-* filtro opzionale specifico per Gallica:
-  * `Tutti i materiali` (default),
-  * `Solo manoscritti`,
-  * `Solo libri a stampa`.
+If `/studio` is opened without a document context, the app shows a recent-work hub instead of an empty editor. This is expected behavior and is backed by persisted server-side context.
 
-Il numero massimo di risultati per provider è configurabile da **Settings > Discovery** (default: 20, range 1-50).
+### Viewing Modes
 
-Per i provider con API paginate (Archive.org, Harvard, Library of Congress, Gallica), un pulsante **"Carica altri risultati"** in fondo alla lista permette di caricare le pagine successive senza ricaricare la pagina.
+Studio uses two viewing modes for Mirador:
 
-I risultati di Archive.org mostrano anche descrizione, volume e lingua quando disponibili. La validazione del manifest IIIF avviene in modo asincrono per ogni card (badge "Verifica manifest…" → "✓ Manifesto disponibile" / "✗ Non disponibile").
+- `Remote mode` for incomplete downloads or explicit remote-preview requests.
+- `Local mode` for fully available local page sets.
 
-Nota: su Gallica i filtri per tipologia vengono applicati localmente sui metadati (`dc:type`) estratti dai record SRU, perché i filtri CQL diretti su `dc.type` non sono sempre affidabili.
+Mode selection is driven by:
 
-### 🛰️ Smart Resolvers
+- local page availability;
+- `settings.viewer.mirador.require_complete_local_images`;
+- the `allow_remote_preview=1` query override.
 
-Il campo di ricerca accetta input "sporchi". Il sistema normalizza automaticamente:
+Use remote mode when you need to inspect an item before the local download is complete. Use local mode when you need offline-safe study with only local assets.
 
-* **Vaticana**: `Urb. lat. 123` → `MSS_Urb.lat.123`
-* **Gallica**: Accetta Short ID (`bpt6k...`), ARK completi e URL di visualizzazione.
-  * Ricerca testuale libera di default.
-  * Filtri opzionali per restringere a manoscritti o libri a stampa.
-* **Oxford**: Riconosce UUID (case-insensitive) e URL del portale `digital.bodleian`.
+### OCR And Editing
 
-### ⚡ Il "Golden Flow" di Download
+- OCR runs asynchronously.
+- Studio tracks job state and exposes progress in the UI.
+- Transcription saving avoids unnecessary writes when content has not changed.
+- History remains available as document-level working context.
 
-Quando avvii un download, il sistema decide la strategia migliore:
+## Output
 
-1. **Controllo PDF Nativo**: Cerca se la biblioteca offre un PDF ufficiale.
-   * **Se c'è** e `settings.pdf.prefer_native_pdf=true`: lo scarica e **estrae automaticamente** le pagine in immagini JPG ad alta risoluzione (nella cartella `scans/`). Questo garantisce che lo Studio funzioni anche con i PDF.
-   * **Se non c'è**: Scarica le immagini dai server IIIF una per una in area temporanea (`temp_images/{doc_id}`), valida i file e poi li promuove in `scans/` quando la condizione di completezza e soddisfatta.
-1. **Generazione PDF opzionale**: Se (e solo se) il download è avvenuto per immagini sciolte, il sistema genera un PDF compilativo solo con `settings.pdf.create_pdf_from_images=true`.
+The `Output` tab is split into a few related responsibilities:
 
-### 🧪 Strategia immagini: come leggere davvero le opzioni
+- PDF inventory for the current item;
+- PDF generation with profile selection;
+- thumbnail-level page actions;
+- export job monitoring.
 
-Per ogni pagina, il downloader prova una sequenza di size IIIF e solo in fallback passa al tile stitching:
+### PDF Profiles
 
-* `balanced`: `3000 -> 1740 -> max`
-* `quality_first`: `max -> 3000 -> 1740`
-* `fast`: `1740 -> 1200 -> max`
-* `archival`: `max`
-* `custom`: usa `settings.images.download_strategy_custom`
+Profiles define how exports are produced. Typical modes include:
 
-La variabile `settings.images.iiif_quality` non cambia la size: cambia il **profilo cromatico richiesto** nel segmento finale URL (`default/color/gray/bitonal/native`).
+- balanced local export;
+- higher-detail local export;
+- temporary remote high-resolution export.
 
-Indicazioni pratiche:
-* usa `default` per la maggior parte dei manoscritti;
-* usa `gray` o `bitonal` solo quando serve ridurre peso o forzare B/N per workflow OCR specifici;
-* se un server IIIF non supporta una quality, il downloader applica retry/fallback tramite la stessa pipeline di download.
+Use profile selection for the default export decision. Use per-job overrides only for exceptions.
 
-### 🧩 Strategia consigliata per manoscritti molto grandi
+### Page-Level Actions
 
-Per collezioni con pagine molto pesanti, il flusso consigliato e:
-* mantieni nel repository locale una copia **bilanciata** per lavorare veloce in viewer e trascrizione;
-* usa il confronto **Locale / Remote** nel tab `Studio > Output` per capire subito dove il dato dichiarato dal servizio IIIF differisce dal locale;
-* usa **Hi** solo per forzare il miglior diretto disponibile sulla singola pagina;
-* usa **Std** quando vuoi riallineare una pagina alla stessa strategia standard usata dal download automatico del volume;
-* quando serve un PDF finale ad altissima qualita, usa un profilo con `image_source_mode=remote_highres_temp`;
-* abilita `cleanup_temp_after_export` nel profilo per eliminare in automatico i temporanei high-res a fine export.
+The page grid exposes single-page actions such as:
 
-### 🗂️ Staging locale (`temp_images` -> `scans`)
+- direct high-detail refresh;
+- standard refresh using the same strategy as full downloads;
+- local scan optimization when enabled by configuration.
 
-Comportamento runtime attuale:
-* le pagine validate possono essere tenute in `temp_images/{doc_id}` finche il documento non e completo;
-* i retry segmentati (`Retry missing` / `Retry range`) conteggiano anche le pagine gia validate in temp, quindi il sistema converge correttamente alla promozione finale;
-* la policy `settings.storage.partial_promotion_mode` controlla una promozione anticipata:
-  - `never` (default): promozione solo quando il gate di completezza e soddisfatto;
-  - `on_pause`: quando metti in pausa un job running, le pagine validate vengono promosse in `scans`; le scansioni esistenti vengono sovrascritte solo nei flussi espliciti di refresh/ridownload.
+These actions are intended to avoid re-running a full-volume workflow when only a small subset of pages needs attention.
 
-Resume:
-* il resume considera sia `scans/` sia `temp_images/{doc_id}` per capire cosa manca davvero;
-* questo evita duplicazioni e riparte solo dalle pagine effettivamente mancanti.
+## Download And Storage Model
 
-### 📚 Libreria Locale (Local Assets)
+The downloader follows a practical fallback strategy:
 
-Nuova sezione `Libreria`:
-* vista **Grid/List** degli asset locali;
-* raggruppamento per **biblioteca** e **tipologia** (`manoscritto`, `libro a stampa`, `incunabolo`, `periodico`, `altro`);
-* stato per item: `Salvato`, `In download`, `Locale parziale`, `Locale completo`, `Errore`;
-* conteggio pagine locali/temporanee sempre visibile nelle card.
-
-Azioni principali:
-* **Delete** documento locale;
-* **Clean partial** per ripulire download incompleti;
-* **Ottimizza scans locali** (lossy in-place su `scans/`, parametrizzata da Settings);
-* **Retry missing** (riprende solo le pagine mancanti);
-* **Retry range** (intervalli specifici, es. `1-10,15,30-35`).
+1. Prefer a native PDF when the manifest exposes one and configuration allows it.
+2. Extract local images for viewer compatibility when native PDF flow is used.
+3. Fall back to IIIF image download when native PDF is unavailable or not selected.
+4. Optionally build a PDF from images when configured to do so.
 
-### 🛡️ Resilienza di Rete
-
-Il downloader ora "imita" un browser reale (Firefox/Chrome) e gestisce le compressioni (Brotli/Gzip) per aggirare i blocchi (WAF) di biblioteche severe come Gallica.
+Current storage behavior:
 
-## 4. Funzionalità Studio
+- validated pages may remain staged in `temp_images/<doc_id>` before promotion;
+- completed local working pages live in `downloads/<Library>/<DocumentId>/scans/`;
+- PDF outputs live in the document `pdf/` folder;
+- metadata and job artifacts live in the document `data/` folder.
 
-Accesso consigliato:
-* apri un documento dalla pagina **Libreria** tramite "Apri Studio";
-* `/studio` senza `doc_id` e `library` apre il mini-hub **Riprendi lavoro** con gli ultimi contesti Studio persistiti lato server.
-
-### 🖼️ Viewer e Layout
-
-* **Mirador**: Configurato per "Deep Zoom" (`maxZoomLevel` aumentato) per analisi paleografiche dettagliate.
-* **Modalità Visualizzazione Dual-Mode**:
-  - **Modalità Remota** (download incompleti/pause): Mirador carica il manifest originale dal server biblioteca (es. `gallica.bnf.fr`) e mostra TUTTE le pagine, scaricando immagini on-demand. Utile per anteprima durante download. Parametro URL: `?allow_remote_preview=true`.
-  - **Modalità Locale** (download completi): Mirador carica il manifest locale (`/iiif/manifest/...`) e mostra solo le pagine scaricate usando immagini locali. Funziona offline. Default quando `viewer.mirador.require_complete_local_images=true` e tutte le pagine sono disponibili.
-* **Indicatore Stato**: Badge READ_SOURCE nel pannello stato: **AMBRA** per remoto, **VERDE** per locale.
-* **Sidebar**: Collassabile (tasto ☰), lo stato persiste tra le sessioni.
-* **Navigation**: Slider e pulsanti sincronizzati tra Viewer e Editor.
-* **Header stato asset**: in Studio vengono mostrati stato download e badge `Sorgente: Remota/Locale`.
-* **Pannello Stato Professionale**: Badge colorati per stato tecnico (read_source, state, scans, staging, info PDF) con design responsivo.
-
-### ℹ️ Tab Info (riordinato)
-
-Il tab `Info` e stato riorganizzato in sub-tab operative:
-* **Panoramica**: attributi principali documento (titolo, diritti, pagine, direzione lettura, ecc.).
-* **Pagina corrente**: metadati canvas e risorse per la pagina attiva.
-* **Metadati e fonti**: provider, `seeAlso`, endpoint manifesto/servizio IIIF.
-
-Dettagli UX attuali:
-* i link esterni sono resi con CTA esplicite (`Apri ... ↗`) e non mostrano URL lunghi in chiaro;
-* `Canvas ID` e cliccabile in `Pagina corrente` quando il valore e un URL valido;
-* `Diritti` in `Panoramica` e cliccabile se il manifest contiene un link licenza;
-* i blocchi `Vedi anche` sono responsivi e restano nel viewport anche su schermi stretti.
-
-### 🎚️ Visual Tab
-
-* **Filtri Real-time**: Slider per Luminosità, Contrasto, Saturazione, Tonalità e Inversione.
-* **Tecnologia**: I filtri sono applicati via CSS direttamente al Canvas di Mirador, senza modificare i file su disco.
-* **Preset**: Modalità "Notte", "Contrasto Elevato" e "Default".
-
-### ✍️ Trascrizione & OCR
-
-* **Editor**: SimpleMDE (Markdown) con toolbar personalizzata.
-* **OCR Asincrono**:
-  * Cliccando "Run OCR", un worker in background elabora l'immagine.
-  * L'overlay "AI in ascolto" fa polling sullo stato ogni 2 secondi.
-* **Salvataggio Intelligente**:
-  * Il tasto Salva (o Ctrl+S) invia il testo al server.
-  * Il sistema calcola il "Diff": se il testo non è cambiato, evita scritture inutili nel DB.
-  * Feedback visivo immediato tramite Toast.
-
-### 📜 History
-
-* **Versionamento**: Ogni salvataggio crea uno snapshot.
-* **Visualizzazione**: Badge colorati indicano il motore usato (es. "OpenAI", "Manual").
-* **Ripristino**: Il tasto `↺ Ripristina` riporta l'editor a una versione precedente.
-
-## 5. Snippets e Dati
-
-* **Snippet**: Ritagli salvati in `data/local/snippets` e indicizzati nel DB SQLite.
-* **File System**:
-  * `downloads/{Lib}/{ID}/scans/`: Immagini JPG (Sorgente di verità).
-  * `downloads/{Lib}/{ID}/data/`: Metadati JSON e trascrizioni.
-  * `data/local/temp_images/{ID}/`: staging locale delle pagine validate prima della promozione in `scans/`.
-  * `data/vault.db`: Database SQLite per lo stato dei job e ricerche globali.
-
-## 6. Troubleshooting
-
-* **Errore "Connection Reset" o 403 su Gallica**:
-  * Il tuo IP potrebbe essere stato bloccato temporaneamente. Il sistema ora include un sistema di "Backoff" (attesa esponenziale) con rate limiting per host (4 req/min per Gallica). Se il blocco persiste, prova a cambiare rete (es. Hotspot).
-* **Overlay OCR bloccato**:
-  * Controlla i log (`logs/app.log`). Se il worker Python crasha, l'overlay potrebbe non ricevere il segnale di stop. Ricarica la pagina.
-* **PDF scaricato ma Studio vuoto**:
-  * Verifica che l'estrazione delle immagini sia avvenuta. Controlla se la cartella `scans/` contiene file `pag_xxxx.jpg`.
-* **Pagine presenti solo in `temp_images`**:
-  * Comportamento possibile con `partial_promotion_mode=never`: il sistema sta mantenendo staging coerente.
-  * Se ti serve disponibilita immediata in Studio dopo pausa, imposta `settings.storage.partial_promotion_mode=on_pause`.
-* **Studio mostra immagini remote invece di locali**:
-  * Comportamento previsto se download incompleto e `viewer.mirador.require_complete_local_images=true` (default).
-  * Studio usa **Modalità Remota** automaticamente: Mirador carica manifest originale e scarica immagini on-demand dal server biblioteca.
-  * **Badge AMBRA** nel pannello stato indica modalità remota.
-  * Per forzare modalità remota: aggiungi `?allow_remote_preview=true` all'URL Studio.
-  * Per visualizzazione locale: completa il download o imposta `require_complete_local_images=false` in config.
-* **Come visualizzare anteprima manoscritto durante download?**:
-  * Usa `?allow_remote_preview=true` nell'URL Studio per forzare Modalità Remota.
-  * Mirador mostrerà TUTTE le pagine scaricando immagini on-demand dal server originale.
-* **Download Gallica più lenti di altre biblioteche?**:
-  * Comportamento previsto: HTTP Client applica rate limiting più stretto per Gallica (4 req/min vs 20 req/min default).
-  * Motivo: server Gallica usano WAF aggressivo e rate limiting. Limiti conservativi prevengono blocchi IP.
-  * Config: `settings.network.libraries.gallica.*` in `config.json`.
-* **`/studio` non apre subito il documento**:
-  * È comportamento previsto: senza contesto (`doc_id` + `library`) Studio mostra il mini-hub `Riprendi lavoro`.
-
-## 7. Developer Notes
-
-* **Architecture**: Vedi `docs/ARCHITECTURE.md` per il diagramma dei moduli.
-* **Network Layer**: Tutta la logica HTTP è centralizzata in `src/universal_iiif_core/http_client.py` (HTTPClient con retry, backoff, rate limiting) e `src/universal_iiif_core/utils.py` (Session legacy, Headers, WAF Bypass).
-* **HTTP Client**: Documentazione completa in `docs/HTTP_CLIENT.md` (implementation, configuration, migration guide).
-* **Testing**:
-  * Unit test offline (Discovery/Gallica): `pytest tests/test_search_gallica_unit.py tests/test_discovery_handlers_resolve_manifest.py`
-  * Live test (Rete richiesta): `pytest tests/test_live.py` (Abilitare in config).
-
-## 8. Gestione dei dati locali
-
-- I dati runtime (cartelle `downloads/`, `data/local/`, `logs/`, `temp_images/`) sono ritenuti rigenerabili e restano nel `.gitignore`. Il contenuto di `config.json` è invece trattato come fonte primaria e non viene mai cancellato automaticamente.
-- Per cancellare in tutta sicurezza i dati rigenerabili, usa lo script `scripts/clean_user_data.py`. Passa `--dry-run` per vedere cosa verrebbe rimosso, `--yes` per confermare la rimozione e `--include-data-local` solo se devi resettare anche `data/local/models`, `data/local/snippets` o altri componenti generati.
-- Lo script usa `universal_iiif_core.config_manager` per risolvere i percorsi configurati; se aggiungi nuove directory runtime, registra sempre il path tramite il manager e aggiornane `.gitignore`.
-- Come workflow consigliato prima di una PR: (1) `python scripts/clean_user_data.py --dry-run`, (2) `python scripts/clean_user_data.py --yes`, (3) `pytest tests/`, (4) `ruff check . --select C901` + `ruff format .`. Queste istruzioni sono ripetute anche in `AGENTS.md`.
+Promotion timing is controlled by `settings.storage.partial_promotion_mode`.
+
+## Configuration
+
+Runtime settings live in `config.json`.
+
+Use these documents together:
+
+- [Configuration Reference](CONFIG_REFERENCE.md) for the full keyspace.
+- [HTTP Client Notes](HTTP_CLIENT.md) for transport behavior.
+- [Architecture](ARCHITECTURE.md) for system boundaries and component responsibilities.
+
+Important settings families:
+
+- `settings.network.*`
+- `settings.images.*`
+- `settings.pdf.*`
+- `settings.storage.*`
+- `settings.viewer.*`
+- `settings.discovery.*`
+
+## Troubleshooting
+
+`iiif-studio: command not found`
+
+```bash
+source .venv/bin/activate
+pip install -e .
+```
+
+Studio shows remote images instead of local images:
+
+- This is expected when local page availability is incomplete and local-only gating is enabled.
+- Use remote preview intentionally, or complete the local download.
+
+Pages appear staged but not promoted:
+
+- Review `settings.storage.partial_promotion_mode`.
+- `never` keeps staged pages until completeness gates are satisfied.
+- `on_pause` promotes validated staged pages when a running job is paused.
+
+Gallica or other providers feel slow:
+
+- This can be expected under stricter per-library rate limiting and backoff rules.
+- Review `settings.network.global.*` and `settings.network.libraries.<library>.*`.
+
+## Related Docs
+
+- [Documentation Hub](index.md)
+- [Studio Workflow Wiki Page](wiki/Studio-Workflow.md)
+- [PDF Export Profiles Wiki Page](wiki/PDF-Export-Profiles.md)
+- [FAQ](wiki/FAQ.md)

--- a/docs/WIKI_MAINTENANCE.md
+++ b/docs/WIKI_MAINTENANCE.md
@@ -1,60 +1,69 @@
 # Wiki Maintenance Guide
 
-This project uses a "docs-as-source, wiki-as-publish" model.
+This repository uses a `docs-as-source, wiki-as-publish` model.
 
-## Why This Model
+## Source Of Truth
 
-- Documentation quality stays in the main repo (`docs/`) with PR review and CI checks.
-- GitHub Wiki stays lightweight for readers.
-- Sync avoids drift between technical docs and wiki pages.
+- Repository documentation in `docs/` is the primary source of truth.
+- GitHub Wiki content is derived from `docs/wiki/`.
+- The published wiki should remain shorter and more reader-friendly than the full repository documentation.
 
-## Source and Publish Paths
+## Publishing Rules
 
-- Wiki source files: `docs/wiki/`
+- Always edit wiki source pages in `docs/wiki/`.
+- Do not treat the GitHub Wiki as an editable source.
+- Keep wiki pages concise and link back to canonical repo docs for depth.
+- All documentation prose must be English-only.
+
+## Sync Tool
+
+- Source pages: `docs/wiki/`
 - Sync script: `scripts/sync_wiki.py`
-- GitHub Wiki remote: `<repo>.wiki.git`
+- Wiki remote: `<repo>.wiki.git`
+
+The sync script is responsible for more than file copy:
+
+- mirroring wiki source pages into the wiki repository;
+- rewriting links so published pages do not point to non-published local paths;
+- failing in dry-run when a wiki page contains an invalid or non-publishable link.
 
 ## Manual Sync
 
-1. Edit wiki pages under `docs/wiki/`.
-1. Commit and merge to `main`.
-1. Validate with dry-run:
+Dry-run first:
 
 ```bash
 python scripts/sync_wiki.py --repo owner/repo --dry-run
 ```
 
-1. Publish with:
+Publish when dry-run is clean:
 
 ```bash
 python scripts/sync_wiki.py --repo owner/repo --push
 ```
 
-Notes:
+## CI Model
 
-- `Home.md` is required in `docs/wiki/`.
-- By default, sync runs with prune enabled and removes wiki files not present in source.
+The repository already contains a dedicated wiki workflow.
 
-## Automated Sync in CI
+Expected behavior:
 
-A workflow can publish from `main`:
+- `Wiki Sync` runs a dry-run validation first.
+- Publishing only happens after the dry-run job succeeds.
+- The workflow uses `GITHUB_TOKEN` with `contents: write`.
 
-- Trigger on pushes affecting wiki sources.
-- Run a dry-run smoke test first.
-- If dry-run passes, run `scripts/sync_wiki.py --push`.
-- Use `GITHUB_TOKEN` with `contents: write`.
+## Authoring Guidelines
 
-## Script Options
+- Keep page titles stable.
+- Prefer task-oriented headings.
+- Use links to canonical docs instead of duplicating full technical detail.
+- Keep internal wiki links relative within `docs/wiki/`.
+- Use absolute GitHub links only for documents that are not published into the wiki.
 
-```bash
-python scripts/sync_wiki.py --help
-```
+## Required Wiki Pages
 
-Most useful flags:
-
-- `--repo owner/repo`
-- `--source-root docs/wiki`
-- `--wiki-dir /tmp/iiif-wiki-sync`
-- `--dry-run`
-- `--push`
-- `--no-prune`
+- `Home.md`
+- `Getting-Started.md`
+- `Configuration.md`
+- `Studio-Workflow.md`
+- `PDF-Export-Profiles.md`
+- `FAQ.md`

--- a/docs/assets/readme-hero.svg
+++ b/docs/assets/readme-hero.svg
@@ -1,44 +1,47 @@
-<svg width="1600" height="520" viewBox="0 0 1600 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<svg width="1800" height="560" viewBox="0 0 1800 560" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Universal IIIF Downloader and Studio banner</title>
   <desc id="desc">Stylized banner showing the Discovery, Library, Studio, and Export workflow.</desc>
-  <rect width="1600" height="520" rx="28" fill="#07111F"/>
-  <rect x="18" y="18" width="1564" height="484" rx="22" fill="url(#bg)"/>
-  <path d="M104 412C221 297 348 250 498 274C648 298 688 382 854 390C1020 398 1106 282 1284 256C1395 240 1494 257 1542 278V488H104V412Z" fill="url(#wave)" opacity="0.85"/>
-  <circle cx="1314" cy="116" r="118" fill="url(#orb)" opacity="0.45"/>
-  <circle cx="1272" cy="132" r="62" fill="#D8F3FF" opacity="0.28"/>
-  <text x="92" y="138" fill="white" font-size="54" font-family="Arial, Helvetica, sans-serif" font-weight="700">Universal IIIF Downloader &amp; Studio</text>
-  <text x="92" y="188" fill="#C6D4E1" font-size="24" font-family="Arial, Helvetica, sans-serif">Discovery-to-export workflow for IIIF manuscripts, local study copies, and profile-driven PDF output.</text>
+  <rect width="1800" height="560" rx="32" fill="#07111F"/>
+  <rect x="18" y="18" width="1764" height="524" rx="24" fill="url(#bg)"/>
+  <path d="M108 446C244 312 394 252 570 278C746 304 802 402 994 408C1186 414 1292 294 1496 262C1616 243 1716 262 1738 276V524H108V446Z" fill="url(#wave)" opacity="0.88"/>
+  <circle cx="1488" cy="126" r="132" fill="url(#orb)" opacity="0.45"/>
+  <circle cx="1436" cy="144" r="76" fill="#D8F3FF" opacity="0.26"/>
+  <rect x="94" y="80" width="152" height="32" rx="16" fill="#0F1B2D" stroke="#3ABFF8" stroke-width="1.5"/>
+  <text x="116" y="101" fill="#9FE8FF" font-size="16" font-family="Arial, Helvetica, sans-serif" font-weight="700">IIIF WORKFLOW</text>
+  <text x="92" y="166" fill="white" font-size="62" font-family="Arial, Helvetica, sans-serif" font-weight="700">Universal IIIF Downloader &amp; Studio</text>
+  <text x="92" y="216" fill="#C6D4E1" font-size="26" font-family="Arial, Helvetica, sans-serif">Discovery-to-export workflow for IIIF manuscripts, local study copies, and profile-driven PDF output.</text>
+  <text x="92" y="258" fill="#8FB3C9" font-size="20" font-family="Arial, Helvetica, sans-serif">Shared provider resolution. Local-first study flow. Profile-driven output. Built for demanding source material.</text>
 
-  <g transform="translate(90 278)">
-    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#3ABFF8" stroke-width="2"/>
-    <text x="26" y="42" fill="#8BE9FD" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">DISCOVERY</text>
-    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Resolve, search, prefetch</text>
+  <g transform="translate(88 318)">
+    <rect width="286" height="116" rx="20" fill="#0F1B2D" stroke="#3ABFF8" stroke-width="2"/>
+    <text x="28" y="44" fill="#8BE9FD" font-size="19" font-family="Arial, Helvetica, sans-serif" font-weight="700">DISCOVERY</text>
+    <text x="28" y="78" fill="#DBE7F2" font-size="22" font-family="Arial, Helvetica, sans-serif">Resolve, search, prefetch</text>
   </g>
 
-  <g transform="translate(390 278)">
-    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#5EEAD4" stroke-width="2"/>
-    <text x="26" y="42" fill="#99F6E4" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">LIBRARY</text>
-    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Track local assets</text>
+  <g transform="translate(414 318)">
+    <rect width="286" height="116" rx="20" fill="#0F1B2D" stroke="#5EEAD4" stroke-width="2"/>
+    <text x="28" y="44" fill="#99F6E4" font-size="19" font-family="Arial, Helvetica, sans-serif" font-weight="700">LIBRARY</text>
+    <text x="28" y="78" fill="#DBE7F2" font-size="22" font-family="Arial, Helvetica, sans-serif">Track local assets</text>
   </g>
 
-  <g transform="translate(690 278)">
-    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#F59E0B" stroke-width="2"/>
-    <text x="26" y="42" fill="#FCD34D" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">STUDIO</text>
-    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Read, annotate, inspect</text>
+  <g transform="translate(740 318)">
+    <rect width="286" height="116" rx="20" fill="#0F1B2D" stroke="#F59E0B" stroke-width="2"/>
+    <text x="28" y="44" fill="#FCD34D" font-size="19" font-family="Arial, Helvetica, sans-serif" font-weight="700">STUDIO</text>
+    <text x="28" y="78" fill="#DBE7F2" font-size="22" font-family="Arial, Helvetica, sans-serif">Read, annotate, inspect</text>
   </g>
 
-  <g transform="translate(990 278)">
-    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#FB7185" stroke-width="2"/>
-    <text x="26" y="42" fill="#FDA4AF" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">OUTPUT</text>
-    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Profiles, jobs, PDF export</text>
+  <g transform="translate(1066 318)">
+    <rect width="286" height="116" rx="20" fill="#0F1B2D" stroke="#FB7185" stroke-width="2"/>
+    <text x="28" y="44" fill="#FDA4AF" font-size="19" font-family="Arial, Helvetica, sans-serif" font-weight="700">OUTPUT</text>
+    <text x="28" y="78" fill="#DBE7F2" font-size="22" font-family="Arial, Helvetica, sans-serif">Profiles, jobs, PDF export</text>
   </g>
 
-  <path d="M342 332H388" stroke="#82E9FF" stroke-width="4" stroke-linecap="round"/>
-  <path d="M642 332H688" stroke="#82F3D4" stroke-width="4" stroke-linecap="round"/>
-  <path d="M942 332H988" stroke="#FCD34D" stroke-width="4" stroke-linecap="round"/>
-  <path d="M374 318L392 332L374 346" stroke="#82E9FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M674 318L692 332L674 346" stroke="#82F3D4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M974 318L992 332L974 346" stroke="#FCD34D" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M374 376H412" stroke="#82E9FF" stroke-width="4" stroke-linecap="round"/>
+  <path d="M700 376H738" stroke="#82F3D4" stroke-width="4" stroke-linecap="round"/>
+  <path d="M1026 376H1064" stroke="#FCD34D" stroke-width="4" stroke-linecap="round"/>
+  <path d="M398 362L416 376L398 390" stroke="#82E9FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M724 362L742 376L724 390" stroke="#82F3D4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M1050 362L1068 376L1050 390" stroke="#FCD34D" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 
   <defs>
     <linearGradient id="bg" x1="106" y1="36" x2="1486" y2="470" gradientUnits="userSpaceOnUse">

--- a/docs/assets/readme-hero.svg
+++ b/docs/assets/readme-hero.svg
@@ -1,0 +1,59 @@
+<svg width="1600" height="520" viewBox="0 0 1600 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Universal IIIF Downloader and Studio banner</title>
+  <desc id="desc">Stylized banner showing the Discovery, Library, Studio, and Export workflow.</desc>
+  <rect width="1600" height="520" rx="28" fill="#07111F"/>
+  <rect x="18" y="18" width="1564" height="484" rx="22" fill="url(#bg)"/>
+  <path d="M104 412C221 297 348 250 498 274C648 298 688 382 854 390C1020 398 1106 282 1284 256C1395 240 1494 257 1542 278V488H104V412Z" fill="url(#wave)" opacity="0.85"/>
+  <circle cx="1314" cy="116" r="118" fill="url(#orb)" opacity="0.45"/>
+  <circle cx="1272" cy="132" r="62" fill="#D8F3FF" opacity="0.28"/>
+  <text x="92" y="138" fill="white" font-size="54" font-family="Arial, Helvetica, sans-serif" font-weight="700">Universal IIIF Downloader &amp; Studio</text>
+  <text x="92" y="188" fill="#C6D4E1" font-size="24" font-family="Arial, Helvetica, sans-serif">Discovery-to-export workflow for IIIF manuscripts, local study copies, and profile-driven PDF output.</text>
+
+  <g transform="translate(90 278)">
+    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#3ABFF8" stroke-width="2"/>
+    <text x="26" y="42" fill="#8BE9FD" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">DISCOVERY</text>
+    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Resolve, search, prefetch</text>
+  </g>
+
+  <g transform="translate(390 278)">
+    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#5EEAD4" stroke-width="2"/>
+    <text x="26" y="42" fill="#99F6E4" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">LIBRARY</text>
+    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Track local assets</text>
+  </g>
+
+  <g transform="translate(690 278)">
+    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#F59E0B" stroke-width="2"/>
+    <text x="26" y="42" fill="#FCD34D" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">STUDIO</text>
+    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Read, annotate, inspect</text>
+  </g>
+
+  <g transform="translate(990 278)">
+    <rect width="250" height="108" rx="18" fill="#0F1B2D" stroke="#FB7185" stroke-width="2"/>
+    <text x="26" y="42" fill="#FDA4AF" font-size="18" font-family="Arial, Helvetica, sans-serif" font-weight="700">OUTPUT</text>
+    <text x="26" y="74" fill="#DBE7F2" font-size="20" font-family="Arial, Helvetica, sans-serif">Profiles, jobs, PDF export</text>
+  </g>
+
+  <path d="M342 332H388" stroke="#82E9FF" stroke-width="4" stroke-linecap="round"/>
+  <path d="M642 332H688" stroke="#82F3D4" stroke-width="4" stroke-linecap="round"/>
+  <path d="M942 332H988" stroke="#FCD34D" stroke-width="4" stroke-linecap="round"/>
+  <path d="M374 318L392 332L374 346" stroke="#82E9FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M674 318L692 332L674 346" stroke="#82F3D4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M974 318L992 332L974 346" stroke="#FCD34D" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <defs>
+    <linearGradient id="bg" x1="106" y1="36" x2="1486" y2="470" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0A1628"/>
+      <stop offset="0.52" stop-color="#0C2037"/>
+      <stop offset="1" stop-color="#0C1728"/>
+    </linearGradient>
+    <linearGradient id="wave" x1="104" y1="260" x2="1542" y2="454" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1D4ED8"/>
+      <stop offset="0.45" stop-color="#0891B2"/>
+      <stop offset="1" stop-color="#0F766E"/>
+    </linearGradient>
+    <radialGradient id="orb" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1314 116) rotate(90) scale(118)">
+      <stop stop-color="#7DD3FC"/>
+      <stop offset="1" stop-color="#7DD3FC" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# Documentation Hub
+
+Use this page as the primary navigation layer for repository documentation.
+
+## Start Here
+
+- [README](../README.md) for first install and quickstart.
+- [Getting Started Wiki Page](wiki/Getting-Started.md) for a reader-friendly overview.
+
+## User Guides
+
+- [User Guide](DOCUMENTAZIONE.md)
+- [Studio Workflow Wiki Page](wiki/Studio-Workflow.md)
+- [PDF Export Profiles Wiki Page](wiki/PDF-Export-Profiles.md)
+- [FAQ](wiki/FAQ.md)
+
+## Reference
+
+- [Configuration Reference](CONFIG_REFERENCE.md)
+- [HTTP Client Notes](HTTP_CLIENT.md)
+
+## Architecture And Maintenance
+
+- [Architecture](ARCHITECTURE.md)
+- [Wiki Maintenance](WIKI_MAINTENANCE.md)
+- [Issue Triage Policy](ISSUE_TRIAGE_POLICY.md)
+
+## Publishing Model
+
+- Repository docs under `docs/` are the source of truth.
+- `docs/wiki/` contains curated pages that are published to the GitHub Wiki.
+- Documentation prose is English-only. Product UI labels may appear in their original form when quoted.

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -39,6 +39,6 @@ Runtime settings live in `config.json` and are resolved through `universal_iiif_
 
 ## Canonical References
 
-- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [Documentation Hub](../index.md)
 - [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
 - [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -1,74 +1,44 @@
 # Configuration
 
-Runtime settings live in `config.json` and are managed through `universal_iiif_core.config_manager`.
+Runtime settings live in `config.json` and are resolved through `universal_iiif_core.config_manager`.
 
-## Essential Sections
+## Main Sections
 
-- `paths`: runtime directories (`downloads`, `exports`, `temp`, `logs`, `models`, `snippets`).
-- `settings.network.global`: global HTTP transport (timeout, retries, max concurrent jobs).
-- `settings.network.download`: default download policies (workers, delays, retry, backoff).
-- `settings.network.libraries.<library>`: per-library network policies for HTTPClient (rate limiting, concurrency, backoff - e.g., Gallica has stricter limits).
-- `settings.images`: IIIF fetch strategy, local optimization, and stitch limits.
-- `settings.pdf`: native PDF behavior, export defaults, and profile catalog.
-- `settings.storage`: retention and staging-to-scans promotion policy.
-- `settings.viewer`: mirador gating/source policy and OpenSeadragon tuning.
+- `paths` for runtime directories.
+- `security` for allowed origins.
+- `api_keys` for OCR and remote service credentials.
+- `settings.network.*` for transport behavior.
+- `settings.images.*` for page download strategy and local optimization.
+- `settings.pdf.*` for native PDF behavior and export profiles.
+- `settings.storage.*` for retention and staged-page promotion.
+- `settings.viewer.*` for read-source policy and Mirador behavior.
+- `settings.discovery.*` for search result sizing.
 
-## Essential PDF Keys
+## High-Impact Keys
 
+- `settings.network.global.max_concurrent_download_jobs`
+- `settings.network.global.connect_timeout_s`
+- `settings.network.global.read_timeout_s`
+- `settings.network.global.transport_retries`
+- `settings.network.global.per_host_concurrency`
+- `settings.network.download.default_retry_max_attempts`
+- `settings.images.download_strategy_mode`
+- `settings.images.stitch_mode_default`
 - `settings.pdf.prefer_native_pdf`
 - `settings.pdf.create_pdf_from_images`
-- `settings.pdf.viewer_dpi`
-- `settings.pdf.viewer_jpeg_quality`
 - `settings.pdf.profiles.default`
-- `settings.pdf.profiles.catalog.<profile>.image_source_mode`
-- `settings.pdf.profiles.catalog.<profile>.max_parallel_page_fetch`
+- `settings.storage.partial_promotion_mode`
+- `settings.viewer.mirador.require_complete_local_images`
 
-## Essential Storage/Viewer Keys
+## Practical Notes
 
-- `settings.storage.partial_promotion_mode` (`never|on_pause`)
-- `settings.storage.remote_cache.max_bytes|retention_hours|max_items`
-- `settings.viewer.mirador.require_complete_local_images` (default: `true` - gates viewer until complete; set `false` or use `?allow_remote_preview=true` for remote preview mode)
-- `settings.viewer.source_policy.saved_mode` (`remote_first|local_first`)
-
-## Essential Network/HTTP Client Keys
-
-- `settings.network.global.max_concurrent_download_jobs` (default: `2`)
-- `settings.network.global.connect_timeout_s` / `read_timeout_s` (global timeout for all libraries)
-- `settings.network.download.default_retry_max_attempts` / `default_backoff_base_s` (default retry/backoff)
-- `settings.network.libraries.<library>.use_custom_policy` (enable per-library overrides)
-- `settings.network.libraries.<library>.burst_max_requests` / `burst_window_s` (rate limiting - e.g., Gallica: 4 req/60s)
-- `settings.network.libraries.<library>.per_host_concurrency` (max parallel requests per host - e.g., Gallica: 2, others: 4)
-
-## Essential Local Optimization Keys
-
-- `settings.images.local_optimize.max_long_edge_px`
-- `settings.images.local_optimize.jpeg_quality`
-
-## Essential Image Strategy Keys
-
-- `settings.images.download_strategy_mode`
-- `settings.images.download_strategy_custom`
-- `settings.images.stitch_mode_default`
-- `settings.images.iiif_quality`
-- `settings.images.tile_stitch_max_ram_gb`
-
-## Notes
-
-- `settings.network.global.*` is always shared across libraries (no per-library timeout/concurrency override).
-- `settings.network.libraries.<library>.*` applies only when `use_custom_policy=true`.
-- HTTPClient automatically applies per-library rate limiting and backoff (Gallica: 4 req/min, others: 20 req/min).
-- Keep local scans balanced by default for speed and storage.
-- Use export profiles for job-level quality decisions instead of changing global defaults frequently.
-- `download_strategy_custom` is an ordered attempt list (`3000`, `1740`, `max`), not a guarantee that `max` is the largest actual image a server will return.
-- `stitch_mode_default` controls whether the standard page downloader can fall back to tile stitching after direct IIIF attempts.
-- `iiif_quality` changes the IIIF URL quality segment only; it does not decide the requested size.
-- Staged downloads can live in `temp_images/<doc_id>` before promotion to `scans/`.
-- Segmented retries/range downloads count previously staged validated pages before final promotion.
-- With `partial_promotion_mode=on_pause`, promotion on pause keeps existing scans by default and overwrites only for explicit refresh/redownload flows.
-- Mirador viewing modes: Remote Mode (incomplete downloads, fetches images on-demand) vs Local Mode (complete downloads, offline-capable).
+- Keep local workflows balanced by default.
+- Use export profiles for quality changes instead of repeatedly editing global settings.
+- Treat `download_strategy_custom` as an ordered attempt list, not a promise that one value is always the largest real image.
+- Remote preview and local-only viewing behavior are controlled by the combination of local availability, config policy, and explicit URL override.
 
 ## Canonical References
 
-- Main user guide: [DOCUMENTAZIONE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-- Full key reference: [CONFIG_REFERENCE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
-- Architecture notes: [ARCHITECTURE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
+- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
+- [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,9 +1,8 @@
 # FAQ
 
-## 1) `iiif-studio: command not found`
+## `iiif-studio: command not found`
 
-**Probable cause**: the virtual environment is not active or the project is not installed in editable mode.  
-**Quick fix**:
+Activate the virtual environment and reinstall in editable mode:
 
 ```bash
 source .venv/bin/activate
@@ -11,134 +10,63 @@ pip install -e .
 iiif-studio
 ```
 
-More details: [README.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/README.md)
+## Studio opens without a document
 
-## 2) Port `8000` is already in use
+This is expected. Opening `/studio` without `doc_id` and `library` shows the recent-work hub.
 
-**Probable cause**: another process is already bound to the web port.  
-**Quick fix**: stop the conflicting process, then rerun `iiif-studio`.
+## Studio shows remote images instead of local images
 
-More details: [README troubleshooting](https://github.com/nikazzio/universal-iiif-studio/blob/main/README.md)
+This is expected when local page availability is incomplete and local-only gating is enabled.
 
-## 3) Manifest cannot be resolved
+Review:
 
-**Probable cause**: wrong URL, temporary provider outage, or access restrictions.  
-**Quick fix**:
-- verify the manifest URL in the browser first,
-- retry after a few minutes,
-- switch provider if available.
-
-More details: [DOCUMENTAZIONE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-
-## 4) Download stops midway
-
-**Probable cause**: network timeout or remote rate limiting.  
-**Quick fix**:
-- retry after a short wait,
-- reduce concurrency if your network is unstable,
-- avoid starting multiple heavy jobs at once.
-
-More details: [CONFIG_REFERENCE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
-
-## 5) Studio opens but pages are missing
-
-**Probable cause**: scans were not extracted/downloaded as expected.  
-**Quick fix**:
-- check the document folder under `downloads/...`,
-- check staging under `data/local/temp_images/<doc_id>/`,
-- verify scans are present before opening Studio,
-- retry extraction/download for missing pages.
-
-If pages are staged but not promoted yet, review:
-- `settings.storage.partial_promotion_mode` (`never|on_pause`)
 - `settings.viewer.mirador.require_complete_local_images`
+- the `allow_remote_preview=1` query override
+- current local page availability in the item workspace
 
-More details: [ARCHITECTURE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
+## Why are pages still in staging?
 
-## 6) Pause works, but why are some pages still in temp?
+`settings.storage.partial_promotion_mode` controls when validated staged pages are promoted into local scans.
 
-**Behavior**:
-- with `partial_promotion_mode=never`, validated pages can remain in staging until completeness gate is satisfied;
-- with `partial_promotion_mode=on_pause`, pausing promotes validated staged pages to `scans/`; existing scans are overwritten only in explicit refresh/redownload flows.
+- `never` keeps them staged until completeness gates are satisfied.
+- `on_pause` promotes validated staged pages when a running job is paused.
 
-Segmented retries (`retry_missing` / `retry_range`) still converge correctly because completeness checks count previously staged validated pages.
+## Which PDF source is used?
 
-## 7) Native PDF vs generated PDF: which one is used?
+- Native PDF is preferred when the manifest exposes one and `settings.pdf.prefer_native_pdf=true`.
+- Otherwise the workflow falls back to image-based download.
+- Image-based PDF generation depends on `settings.pdf.create_pdf_from_images`.
 
-**Behavior**:
-- if the manifest exposes a native PDF and `settings.pdf.prefer_native_pdf=true`, native flow is preferred;
-- otherwise images are used, and PDF generation depends on `settings.pdf.create_pdf_from_images`.
+## Can I export higher quality without keeping everything high resolution locally?
 
-More details: [CONFIG_REFERENCE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
+Yes. Use a PDF profile that fetches temporary remote high-resolution images for the export job.
 
-## 8) Can I export very high quality PDF without keeping everything high-res locally?
+## Why do some providers feel slower than others?
 
-Yes. Use an export profile with `image_source_mode=remote_highres_temp`.
-High-res pages are fetched for that job and cleaned after export when enabled.
+Per-library rate limiting and backoff settings can be stricter for fragile upstream services. Review `settings.network.global.*` and `settings.network.libraries.<library>.*`.
 
-More details: [PDF-Export-Profiles](PDF-Export-Profiles.md)
+## Wiki sync ran, but the wiki did not update
 
-## 9) Wiki sync ran, but wiki was not updated
-
-**Probable cause**: push not enabled, wiki disabled, or missing permissions.  
-**Quick fix**:
-- run dry-run first to verify delta:
+Run a dry-run first:
 
 ```bash
 python scripts/sync_wiki.py --repo owner/repo --dry-run
 ```
 
-- then publish with `--push`,
-- ensure CI has `contents: write` and wiki is enabled.
+Then publish:
 
-More details: [WIKI_MAINTENANCE.md](../WIKI_MAINTENANCE.md)
+```bash
+python scripts/sync_wiki.py --repo owner/repo --push
+```
 
-## 10) Where should I edit wiki pages?
+Also confirm that the repository wiki is enabled and that the workflow token has `contents: write`.
 
-Always edit source pages in `docs/wiki/` inside the main repository.  
-The GitHub wiki is a publish target, not the source of truth.
+## Where should I edit wiki pages?
 
-More details: [WIKI_MAINTENANCE.md](../WIKI_MAINTENANCE.md)
+Always edit source pages in `docs/wiki/` inside the main repository. The GitHub Wiki is a publish target, not the source of truth.
 
-## 11) Where is the complete configuration reference?
+## Read Next
 
-Use the canonical docs:
-- full keys: [CONFIG_REFERENCE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
-- user flow: [DOCUMENTAZIONE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-- architecture: [ARCHITECTURE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
-
-## 12) Why does Studio show remote images instead of local ones?
-
-**Probable cause**: Download is incomplete or `viewer.mirador.require_complete_local_images=true` (default).  
-**Behavior**: Studio automatically uses **Remote Mode** when local pages are not fully available. Mirador loads the original manifest and fetches images on-demand from the library server.  
-**Quick fix**:
-- Complete the download to automatically switch to Local Mode.
-- Or add `?allow_remote_preview=true` to Studio URL to explicitly enable Remote Mode.
-- Or set `viewer.mirador.require_complete_local_images=false` in config to prefer remote preview by default.
-
-**Status indicator**: Check the READ_SOURCE badge in the status panel:
-- **AMBER badge**: Remote mode (fetching from original server)
-- **GREEN badge**: Local mode (using downloaded images)
-
-More details: [Studio-Workflow.md](Studio-Workflow.md)
-
-## 13) How do I preview a manuscript while it's still downloading?
-
-**Solution**: Use Remote Mode by adding `?allow_remote_preview=true` to the Studio URL.  
-**Behavior**: Mirador will load the original manifest from the library server and display ALL pages, fetching images on-demand as you navigate.  
-**Limitation**: Requires internet connection; images are not cached locally in this mode.
-
-More details: [Studio-Workflow.md](Studio-Workflow.md)
-
-## 14) Why do downloads to Gallica seem slower than other libraries?
-
-**Expected behavior**: Gallica has stricter rate limits configured in the HTTP client.  
-**Rate limits**:
-- Gallica: 4 requests per minute (burst window)
-- Other libraries: 20 requests per minute (default)
-
-**Rationale**: Gallica servers use aggressive WAF (Web Application Firewall) and rate limiting. The system automatically applies conservative limits to avoid IP blocks.
-
-**Config location**: `settings.network.libraries.gallica.*` in `config.json`.
-
-More details: [HTTP_CLIENT.md](../HTTP_CLIENT.md)
+- [Studio Workflow](Studio-Workflow.md)
+- [Configuration](Configuration.md)
+- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -69,4 +69,4 @@ Always edit source pages in `docs/wiki/` inside the main repository. The GitHub 
 
 - [Studio Workflow](Studio-Workflow.md)
 - [Configuration](Configuration.md)
-- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [Documentation Hub](../index.md)

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -32,6 +32,6 @@ If `/studio` is opened without `doc_id` and `library`, the app shows the recent-
 
 ## Read Next
 
-- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [Documentation Hub](../index.md)
 - [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
 - [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Quick setup for running Universal IIIF Studio locally.
+Use this page for the shortest path to a working local install.
 
 ## Quick Start
 
@@ -21,20 +21,17 @@ Open `http://127.0.0.1:8000`.
 iiif-cli "<manifest-url>"
 ```
 
-## Main Navigation (Web Studio)
+## Main Navigation
 
-- `Discovery`: resolve and queue downloads.
-  - `Aggiungi item` performs light prefetch (`metadata.json` + `manifest.json`) without full scans.
-- `Library`: local assets entrypoint.
-- `Studio`: document workspace.
-  - **Note**: Opening `/studio` without query parameters (`doc_id` and `library`) shows the **Riprendi lavoro** (Recent Documents) hub, which displays server-side persisted document contexts for quick access to recently viewed items.
-- `Export`: batch/single export hub.
-  - Inside Studio, the per-item tab is named `Output`.
+- `Discovery` resolves provider inputs and search results.
+- `Library` is the canonical entrypoint for local items.
+- `Studio` is the working workspace for a selected document.
+- `Output` is the export surface inside Studio.
 
-If a download is paused/incomplete, pages may temporarily stay in `data/local/temp_images/<doc_id>` before promotion to `downloads/<library>/<doc_id>/scans/`, depending on `settings.storage.partial_promotion_mode`.
+If `/studio` is opened without `doc_id` and `library`, the app shows the recent-work hub instead of an empty editor.
 
-## Canonical Docs
+## Read Next
 
-- Full setup and troubleshooting: [README.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/README.md)
-- User guide: [DOCUMENTAZIONE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-- Architecture details: [ARCHITECTURE.md](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
+- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
+- [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -12,7 +12,7 @@ This wiki is published from repository-managed source files under `docs/wiki/`.
 
 ## Canonical Repository Docs
 
-- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [Documentation Hub](../index.md)
 - [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
 - [Architecture](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
 - [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,8 +1,8 @@
-# Universal IIIF Studio Wiki
+# Universal IIIF Downloader & Studio Wiki
 
-This wiki is maintained from repository sources under `docs/wiki/`.
+This wiki is published from repository-managed source files under `docs/wiki/`.
 
-## Pages
+## Start Here
 
 - [Getting Started](Getting-Started.md)
 - [Configuration](Configuration.md)
@@ -10,8 +10,15 @@ This wiki is maintained from repository sources under `docs/wiki/`.
 - [PDF Export Profiles](PDF-Export-Profiles.md)
 - [FAQ](FAQ.md)
 
-## Maintenance Policy
+## Canonical Repository Docs
 
-- Source of truth for wiki pages: `docs/wiki/`.
-- Sync tool: `python scripts/sync_wiki.py`.
-- Recommended publication flow: merge docs changes to `main`, then sync wiki from CI.
+- [Documentation Hub](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/index.md)
+- [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
+- [Architecture](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
+- [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
+
+## Maintenance Model
+
+- Repository docs are the source of truth.
+- Wiki pages are curated publish targets.
+- Edit wiki source files in `docs/wiki/`, not the GitHub Wiki directly.

--- a/scripts/check_docs_integrity.py
+++ b/scripts/check_docs_integrity.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate key documentation invariants used by CI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class ValidationError(RuntimeError):
+    """Raised when documentation integrity checks fail."""
+
+
+REQUIRED_FILES = [
+    Path("README.md"),
+    Path("docs/index.md"),
+    Path("docs/DOCUMENTAZIONE.md"),
+    Path("docs/ARCHITECTURE.md"),
+    Path("docs/CONFIG_REFERENCE.md"),
+    Path("docs/WIKI_MAINTENANCE.md"),
+    Path("docs/wiki/Home.md"),
+]
+
+REQUIRED_README_LINKS = [
+    "(docs/index.md)",
+    "(docs/DOCUMENTAZIONE.md)",
+    "(docs/ARCHITECTURE.md)",
+    "(docs/CONFIG_REFERENCE.md)",
+]
+
+CRITICAL_CONFIG_KEYS = [
+    "settings.network.global.max_concurrent_download_jobs",
+    "settings.network.global.connect_timeout_s",
+    "settings.network.global.read_timeout_s",
+    "settings.network.global.transport_retries",
+    "settings.network.global.per_host_concurrency",
+    "settings.images.download_strategy_mode",
+    "settings.images.stitch_mode_default",
+    "settings.pdf.prefer_native_pdf",
+    "settings.pdf.create_pdf_from_images",
+    "settings.storage.partial_promotion_mode",
+    "settings.viewer.mirador.require_complete_local_images",
+]
+
+ARCHITECTURE_MARKERS = [
+    "studio_ui/routes/_studio/",
+    "studio_ui/components/settings/panes/",
+    "studio_ui/components/studio/export/",
+]
+
+
+def _must_exist(path: Path, failures: list[str]) -> None:
+    if not path.exists():
+        failures.append(f"Missing required documentation file: {path}")
+
+
+def main() -> int:
+    """Run documentation integrity validation."""
+    failures: list[str] = []
+
+    for path in REQUIRED_FILES:
+        _must_exist(path, failures)
+
+    readme_text = Path("README.md").read_text(encoding="utf-8")
+    for link in REQUIRED_README_LINKS:
+        if link not in readme_text:
+            failures.append(f"README.md is missing required documentation link: {link}")
+
+    config_reference = Path("docs/CONFIG_REFERENCE.md").read_text(encoding="utf-8")
+    for key in CRITICAL_CONFIG_KEYS:
+        if key not in config_reference:
+            failures.append(f"docs/CONFIG_REFERENCE.md is missing critical key: {key}")
+
+    architecture = Path("docs/ARCHITECTURE.md").read_text(encoding="utf-8")
+    for marker in ARCHITECTURE_MARKERS:
+        if marker not in architecture:
+            failures.append(f"docs/ARCHITECTURE.md is missing current package marker: {marker}")
+
+    if failures:
+        details = "\n".join(f"- {item}" for item in failures)
+        raise ValidationError(f"Documentation integrity check failed:\n{details}")
+
+    print("Documentation integrity check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_docs_language.py
+++ b/scripts/check_docs_language.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Fail when a markdown document mixes English and Italian significantly.
-
-Policy:
-- Most markdown files are expected to be English.
-- `docs/DOCUMENTAZIONE.md` is expected to be Italian.
-- A file fails if both language scores are significant, or if dominant language
-  does not match the file expectation.
-"""
+"""Fail when markdown documentation is not predominantly English prose."""
 
 from __future__ import annotations
 
@@ -15,15 +8,12 @@ import sys
 from pathlib import Path
 
 DOC_FILES = [
-    *sorted(Path("docs").glob("*.md")),
     Path("README.md"),
+    *sorted(Path("docs").rglob("*.md")),
+    Path("tests/README.md"),
     Path("AGENTS.md"),
     Path("CHANGELOG.md"),
 ]
-
-EXPECTED_LANGUAGE: dict[str, str] = {
-    "docs/DOCUMENTAZIONE.md": "it",
-}
 
 EN_WORDS = {
     "the",
@@ -44,12 +34,15 @@ EN_WORDS = {
     "added",
     "changed",
     "fixed",
+    "guide",
+    "local",
+    "viewer",
+    "profile",
 }
 
 IT_WORDS = {
     "e",
     "con",
-    # "per" removed - highly ambiguous with English (per-host, per-library, per-instance, etc.)
     "questo",
     "questa",
     "deve",
@@ -64,6 +57,9 @@ IT_WORDS = {
     "corretto",
     "cartella",
     "pagina",
+    "lavoro",
+    "remota",
+    "locale",
 }
 
 
@@ -71,8 +67,10 @@ class ValidationError(RuntimeError):
     """Raised when language policy is violated."""
 
 
-def _strip_code_blocks(text: str) -> str:
-    return re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+def _strip_code(text: str) -> str:
+    without_fenced = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    without_inline = re.sub(r"`[^`]+`", " ", without_fenced)
+    return without_inline
 
 
 def _tokenize(text: str) -> list[str]:
@@ -84,12 +82,11 @@ def _score(tokens: list[str], lexicon: set[str]) -> int:
 
 
 def _is_mixed(en_score: int, it_score: int) -> bool:
-    # Significant counts for both dictionaries implies mixed-language prose.
     return en_score >= 6 and it_score >= 6
 
 
 def main() -> int:
-    """Validate language consistency in markdown files."""
+    """Validate that project docs are English-only prose."""
     cli_paths = [Path(p) for p in sys.argv[1:]]
     targets = cli_paths if cli_paths else DOC_FILES
     failures: list[str] = []
@@ -99,24 +96,18 @@ def main() -> int:
             continue
 
         text = path.read_text(encoding="utf-8")
-        normalized = _strip_code_blocks(text)
+        normalized = _strip_code(text)
         tokens = _tokenize(normalized)
 
         en_score = _score(tokens, EN_WORDS)
         it_score = _score(tokens, IT_WORDS)
 
-        expected = EXPECTED_LANGUAGE.get(path.as_posix(), "en")
+        if _is_mixed(en_score, it_score):
+            failures.append(f"{path}: mixed language detected (en_score={en_score}, it_score={it_score}).")
+            continue
 
-        if expected == "en":
-            if _is_mixed(en_score, it_score):
-                failures.append(f"{path}: mixed language detected (en_score={en_score}, it_score={it_score}).")
-                continue
-            if it_score >= 6 and it_score > en_score:
-                failures.append(f"{path}: expected English but Italian appears dominant.")
-
-        if expected == "it" and en_score >= 12 and en_score > int(it_score * 1.8):
-            # Italian docs naturally include technical English terms - be more permissive
-            failures.append(f"{path}: expected Italian but English appears dominant.")
+        if it_score >= 6 and it_score > en_score:
+            failures.append(f"{path}: expected English but Italian appears dominant.")
 
     if failures:
         details = "\n".join(f"- {item}" for item in failures)

--- a/scripts/sync_wiki.py
+++ b/scripts/sync_wiki.py
@@ -15,6 +15,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+MARKDOWN_LINK_RE = re.compile(r"(!?\[[^\]]*]\()([^)]+)(\))")
+
 
 def _run(cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603
@@ -61,19 +63,108 @@ def _iter_source_files(source_root: Path) -> list[Path]:
     return sorted(path for path in source_root.rglob("*") if path.is_file())
 
 
-def _sync_files(*, source_root: Path, wiki_dir: Path, prune: bool) -> tuple[int, int]:
+def _split_target(target: str) -> tuple[str, str]:
+    if "#" in target:
+        base, anchor = target.split("#", 1)
+        return base, f"#{anchor}"
+    return target, ""
+
+
+def _is_external_link(target: str) -> bool:
+    lowered = target.lower()
+    return lowered.startswith(("http://", "https://", "mailto:", "#"))
+
+
+def _repo_relative_path(path: Path, repo_root: Path) -> str:
+    return path.relative_to(repo_root).as_posix()
+
+
+def _rewrite_markdown_links(
+    *,
+    content: str,
+    src: Path,
+    source_root: Path,
+    repo_root: Path,
+    repo_slug: str,
+    repo_ref: str,
+) -> tuple[str, list[str]]:
+    failures: list[str] = []
+
+    def replace(match: re.Match[str]) -> str:
+        prefix, target, suffix = match.groups()
+        if _is_external_link(target):
+            return match.group(0)
+
+        base, anchor = _split_target(target.strip())
+        if not base:
+            return match.group(0)
+
+        resolved = (src.parent / base).resolve()
+        if not resolved.exists():
+            failures.append(f"{src}: link target does not exist: {target}")
+            return match.group(0)
+
+        try:
+            wiki_rel = resolved.relative_to(source_root)
+            new_base = os.path.relpath(wiki_rel.as_posix(), start=src.parent.relative_to(source_root).as_posix())
+            return f"{prefix}{new_base}{anchor}{suffix}"
+        except ValueError:
+            try:
+                repo_rel = _repo_relative_path(resolved, repo_root)
+            except ValueError:
+                failures.append(f"{src}: link target is outside repository root: {target}")
+                return match.group(0)
+            absolute = f"https://github.com/{repo_slug}/blob/{repo_ref}/{repo_rel}{anchor}"
+            return f"{prefix}{absolute}{suffix}"
+
+    rewritten = MARKDOWN_LINK_RE.sub(replace, content)
+    return rewritten, failures
+
+
+def _sync_files(
+    *,
+    source_root: Path,
+    wiki_dir: Path,
+    repo_root: Path,
+    repo_slug: str,
+    repo_ref: str,
+    prune: bool,
+) -> tuple[int, int]:
     copied = 0
     removed = 0
     keep_rel_paths: set[Path] = set()
+    failures: list[str] = []
 
     for src in _iter_source_files(source_root):
         rel = src.relative_to(source_root)
         keep_rel_paths.add(rel)
         dst = wiki_dir / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
+
+        if src.suffix.lower() == ".md":
+            content = src.read_text(encoding="utf-8")
+            rendered, rewrite_failures = _rewrite_markdown_links(
+                content=content,
+                src=src,
+                source_root=source_root,
+                repo_root=repo_root,
+                repo_slug=repo_slug,
+                repo_ref=repo_ref,
+            )
+            failures.extend(rewrite_failures)
+            current = dst.read_text(encoding="utf-8") if dst.exists() else None
+            if current != rendered:
+                dst.write_text(rendered, encoding="utf-8")
+                copied += 1
+            continue
+
         if not dst.exists() or src.read_bytes() != dst.read_bytes():
             shutil.copy2(src, dst)
             copied += 1
+
+    if failures:
+        details = "\n".join(f"- {item}" for item in failures)
+        raise SystemExit(f"Wiki source validation failed:\n{details}")
 
     if prune:
         for path in sorted(wiki_dir.rglob("*"), reverse=True):
@@ -109,6 +200,11 @@ def _parse_args() -> argparse.Namespace:
         "--wiki-dir",
         default=".cache/wiki-sync",
         help="Local clone directory for the wiki repo.",
+    )
+    parser.add_argument(
+        "--repo-ref",
+        default="main",
+        help="Repository ref used when rewriting absolute GitHub links.",
     )
     parser.add_argument(
         "--commit-message",
@@ -156,8 +252,9 @@ def _resolve_repo_slug(explicit_repo: str | None) -> str:
     return repo_slug
 
 
-def _print_run_context(*, repo_slug: str, source_root: Path, wiki_dir: Path) -> None:
+def _print_run_context(*, repo_slug: str, source_root: Path, wiki_dir: Path, repo_ref: str) -> None:
     print(f"Repository: {repo_slug}")
+    print(f"Repository ref: {repo_ref}")
     print(f"Source root: {source_root}")
     print(f"Wiki dir: {wiki_dir}")
 
@@ -213,17 +310,25 @@ def main() -> int:
     """Run wiki synchronization from local source files to the wiki git repository."""
     args = _parse_args()
 
-    source_root = Path(args.source_root).resolve()
+    repo_root = Path(__file__).resolve().parent.parent
+    source_root = (repo_root / args.source_root).resolve()
     wiki_dir = Path(args.wiki_dir).resolve()
     _validate_source_root(source_root)
     repo_slug = _resolve_repo_slug(args.repo)
-    _print_run_context(repo_slug=repo_slug, source_root=source_root, wiki_dir=wiki_dir)
+    _print_run_context(repo_slug=repo_slug, source_root=source_root, wiki_dir=wiki_dir, repo_ref=args.repo_ref)
 
     token = os.getenv("GITHUB_TOKEN")
     remote_url = _build_wiki_remote(repo_slug, token)
     _clone_or_update_wiki_or_exit(remote_url=remote_url, wiki_dir=wiki_dir)
 
-    copied, removed = _sync_files(source_root=source_root, wiki_dir=wiki_dir, prune=bool(args.prune))
+    copied, removed = _sync_files(
+        source_root=source_root,
+        wiki_dir=wiki_dir,
+        repo_root=repo_root,
+        repo_slug=repo_slug,
+        repo_ref=str(args.repo_ref),
+        prune=bool(args.prune),
+    )
 
     if args.dry_run:
         return _handle_dry_run(wiki_dir=wiki_dir, copied=copied, removed=removed, push_requested=args.push)


### PR DESCRIPTION
## Summary
- refresh the README into a cleaner English-first landing page with a stronger hero, ASCII title block, and higher-signal badges
- rewrite the main docs and curated wiki source pages in English around the current codebase shape
- harden docs validation with an integrity check and publish-safe wiki link rewriting
- fix markdown lint issues that were blocking Docs CI

## Related
- Related #66

## Verification
- python3 scripts/check_docs_language.py
- python3 scripts/check_docs_integrity.py
- python3 -m py_compile scripts/check_docs_language.py scripts/check_docs_integrity.py scripts/sync_wiki.py
- python3 scripts/sync_wiki.py --repo nikazzio/universal-iiif-studio --wiki-dir /tmp/iiif-wiki-sync-test --dry-run
- markdownlint "**/*.md"
- git diff --check