### PR TITLE
chore: rebrand to Scriptoria

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md
+    url: https://github.com/nikazzio/scriptoria/blob/main/docs/DOCUMENTAZIONE.md
     about: Read the user and workflow documentation before opening an issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is procedural only. For architectural rationale, see `docs/ARCHITECTUR
 
 ## Scope
 
-- Project: Universal IIIF Downloader & Studio
+- Project: Scriptoria
 - Supported front ends: FastHTML/HTMX UI and CLI
 - Package layout: `src/`
 
@@ -65,8 +65,8 @@ This file is procedural only. For architectural rationale, see `docs/ARCHITECTUR
 
 - Always use project tools from `.venv/bin/` when available (do not assume global executables).
 - Install: `pip install -e .`
-- Run web UI: `iiif-studio` (or `python3 src/studio_app.py`)
-- Run CLI: `iiif-cli "<manifest-url>"`
+- Run web UI: `scriptoria` (or `python3 src/studio_app.py`)
+- Run CLI: `scriptoria-cli "<manifest-url>"`
 - Run tests: `pytest tests/`
 - Lint/fix: `ruff check . --fix`
 - Complexity check: `ruff check . --select C901`
@@ -93,7 +93,7 @@ Pre-PR sequence:
 ## Verification Loop (Before PR)
 
 Run a compact verification loop for every non-trivial change:
-1. Build/start sanity check for touched surface (`iiif-studio` or relevant CLI path).
+1. Build/start sanity check for touched surface (`scriptoria` or relevant CLI path).
 2. Tests: targeted tests first, then `pytest tests/`.
 3. Lint/complexity/format: Ruff checks.
 4. Security spot-check: traversal/path safety, input validation, and secrets.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/ci.yml?branch=main&label=CI&style=flat-square"></a>
-  <a href="https://github.com/nikazzio/universal-iiif-studio/actions/workflows/docs-ci.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/nikazzio/universal-iiif-studio/docs-ci.yml?branch=main&label=Docs&style=flat-square"></a>
+  <a href="https://github.com/nikazzio/scriptoria/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/nikazzio/scriptoria/ci.yml?branch=main&label=CI&style=flat-square"></a>
+  <a href="https://github.com/nikazzio/scriptoria/actions/workflows/docs-ci.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/nikazzio/scriptoria/docs-ci.yml?branch=main&label=Docs&style=flat-square"></a>
   <a href="https://www.python.org/"><img alt="Python 3.10+" src="https://img.shields.io/badge/python-3.10+-3572A5?style=flat-square&logo=python&logoColor=white"></a>
-  <a href="https://github.com/nikazzio/universal-iiif-studio/releases"><img alt="Release" src="https://img.shields.io/github/v/release/nikazzio/universal-iiif-studio?display_name=tag&style=flat-square&color=0b7285"></a>
+  <a href="https://github.com/nikazzio/scriptoria/releases"><img alt="Release" src="https://img.shields.io/github/v/release/nikazzio/scriptoria?display_name=tag&style=flat-square&color=0b7285"></a>
   <a href="LICENSE"><img alt="MIT" src="https://img.shields.io/badge/license-MIT-22d3ee?style=flat-square"></a>
 </p>
 
@@ -16,8 +16,8 @@
 
 ---
 
-> **Web** &nbsp;`iiif-studio` → [127.0.0.1:8000](http://127.0.0.1:8000) &emsp;·&emsp;
-> **CLI** &nbsp;`iiif-cli "<manifest-url>"`
+> **Web** &nbsp;`scriptoria` → [127.0.0.1:8000](http://127.0.0.1:8000) &emsp;·&emsp;
+> **CLI** &nbsp;`scriptoria-cli "<manifest-url>"`
 
 <!-- TODO: add real screenshots
 <p align="center">
@@ -30,11 +30,11 @@
 ## Quickstart
 
 ```bash
-git clone https://github.com/nikazzio/universal-iiif-studio.git
-cd universal-iiif-studio
+git clone https://github.com/nikazzio/scriptoria.git
+cd scriptoria
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
-iiif-studio
+scriptoria
 ```
 
 ## How It Works
@@ -69,7 +69,7 @@ flowchart LR
 ## CLI
 
 ```bash
-iiif-cli "https://digi.vatlib.it/iiif/MSS_Urb.lat.1779/manifest.json"
+scriptoria-cli "https://digi.vatlib.it/iiif/MSS_Urb.lat.1779/manifest.json"
 ```
 
 Any IIIF-compliant manifest URL works directly.
@@ -94,7 +94,7 @@ ruff check . --select C901       # complexity
 ## Troubleshooting
 
 <details>
-<summary><code>iiif-studio: command not found</code></summary>
+<summary><code>scriptoria: command not found</code></summary>
 
 ```bash
 source .venv/bin/activate && pip install -e .
@@ -112,7 +112,7 @@ source .venv/bin/activate && pip install -r requirements-dev.txt
 <details>
 <summary>Port 8000 already in use</summary>
 
-Stop the conflicting process and restart `iiif-studio`.
+Stop the conflicting process and restart `scriptoria`.
 </details>
 
 <details>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Universal IIIF Downloader & Studio separates a Python UI shell from reusable core services:
+Scriptoria separates a Python UI shell from reusable core services:
 
 - `studio_ui/` renders the FastHTML and HTMX interface.
 - `universal_iiif_core/` owns provider resolution, storage, download orchestration, export logic, OCR services, and runtime policy.

--- a/docs/DOCUMENTAZIONE.md
+++ b/docs/DOCUMENTAZIONE.md
@@ -1,6 +1,6 @@
 # User Guide
 
-Universal IIIF Downloader & Studio supports a single working flow:
+Scriptoria supports a single working flow:
 
 1. Find or resolve an item in `Discovery`.
 2. Save or download it into `Library`.

--- a/docs/HTTP_CLIENT.md
+++ b/docs/HTTP_CLIENT.md
@@ -287,7 +287,7 @@ data = http_client.get_json(url, library_name="gallica", timeout=(20, 20))
 
 ## References
 
-- **Issue**: [#71 - Centralized HTTP Client](https://github.com/nikazzio/universal-iiif-studio/issues/71)
+- **Issue**: [#71 - Centralized HTTP Client](https://github.com/nikazzio/scriptoria/issues/71)
 - **Branch**: `feat/issue-71-centralized-http-client`
 - **Implementation Plan**: `~/.copilot/session-state/.../plan.md`
 - **Test Guide**: `~/.copilot/session-state/.../files/manual-tests.md`

--- a/docs/assets/readme-hero.svg
+++ b/docs/assets/readme-hero.svg
@@ -1,5 +1,5 @@
 <svg width="1800" height="560" viewBox="0 0 1800 560" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">Universal IIIF Downloader and Studio banner</title>
+  <title id="title">Scriptoria banner</title>
   <desc id="desc">Stylized banner showing the Discovery, Library, Studio, and Export workflow.</desc>
   <rect width="1800" height="560" rx="32" fill="#07111F"/>
   <rect x="18" y="18" width="1764" height="524" rx="24" fill="url(#bg)"/>
@@ -8,7 +8,7 @@
   <circle cx="1436" cy="144" r="76" fill="#D8F3FF" opacity="0.26"/>
   <rect x="94" y="80" width="152" height="32" rx="16" fill="#0F1B2D" stroke="#3ABFF8" stroke-width="1.5"/>
   <text x="116" y="101" fill="#9FE8FF" font-size="16" font-family="Arial, Helvetica, sans-serif" font-weight="700">IIIF WORKFLOW</text>
-  <text x="92" y="166" fill="white" font-size="62" font-family="Arial, Helvetica, sans-serif" font-weight="700">Universal IIIF Downloader &amp; Studio</text>
+  <text x="92" y="166" fill="white" font-size="62" font-family="Arial, Helvetica, sans-serif" font-weight="700">Scriptoria</text>
   <text x="92" y="216" fill="#C6D4E1" font-size="26" font-family="Arial, Helvetica, sans-serif">Discovery-to-export workflow for IIIF manuscripts, local study copies, and profile-driven PDF output.</text>
   <text x="92" y="258" fill="#8FB3C9" font-size="20" font-family="Arial, Helvetica, sans-serif">Shared provider resolution. Local-first study flow. Profile-driven output. Built for demanding source material.</text>
 

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -40,5 +40,5 @@ Runtime settings live in `config.json` and are resolved through `universal_iiif_
 ## Canonical References
 
 - [Documentation Hub](../index.md)
-- [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-- [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
+- [User Guide](https://github.com/nikazzio/scriptoria/blob/main/docs/DOCUMENTAZIONE.md)
+- [Configuration Reference](https://github.com/nikazzio/scriptoria/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,13 +1,13 @@
 # FAQ
 
-## `iiif-studio: command not found`
+## `scriptoria: command not found`
 
 Activate the virtual environment and reinstall in editable mode:
 
 ```bash
 source .venv/bin/activate
 pip install -e .
-iiif-studio
+scriptoria
 ```
 
 ## Studio opens without a document

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -5,12 +5,12 @@ Use this page for the shortest path to a working local install.
 ## Quick Start
 
 ```bash
-git clone https://github.com/nikazzio/universal-iiif-studio.git
-cd universal-iiif-studio
+git clone https://github.com/nikazzio/scriptoria.git
+cd scriptoria
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e .
-iiif-studio
+scriptoria
 ```
 
 Open `http://127.0.0.1:8000`.
@@ -18,7 +18,7 @@ Open `http://127.0.0.1:8000`.
 ## CLI
 
 ```bash
-iiif-cli "<manifest-url>"
+scriptoria-cli "<manifest-url>"
 ```
 
 ## Main Navigation
@@ -33,5 +33,5 @@ If `/studio` is opened without `doc_id` and `library`, the app shows the recent-
 ## Read Next
 
 - [Documentation Hub](../index.md)
-- [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-- [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
+- [User Guide](https://github.com/nikazzio/scriptoria/blob/main/docs/DOCUMENTAZIONE.md)
+- [Configuration Reference](https://github.com/nikazzio/scriptoria/blob/main/docs/CONFIG_REFERENCE.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,4 +1,4 @@
-# Universal IIIF Downloader & Studio Wiki
+# Scriptoria Wiki
 
 This wiki is published from repository-managed source files under `docs/wiki/`.
 
@@ -13,9 +13,9 @@ This wiki is published from repository-managed source files under `docs/wiki/`.
 ## Canonical Repository Docs
 
 - [Documentation Hub](../index.md)
-- [User Guide](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/DOCUMENTAZIONE.md)
-- [Architecture](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/ARCHITECTURE.md)
-- [Configuration Reference](https://github.com/nikazzio/universal-iiif-studio/blob/main/docs/CONFIG_REFERENCE.md)
+- [User Guide](https://github.com/nikazzio/scriptoria/blob/main/docs/DOCUMENTAZIONE.md)
+- [Architecture](https://github.com/nikazzio/scriptoria/blob/main/docs/ARCHITECTURE.md)
+- [Configuration Reference](https://github.com/nikazzio/scriptoria/blob/main/docs/CONFIG_REFERENCE.md)
 
 ## Maintenance Model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "universal-iiif"
 version = "0.25.3"
-description = "Universal IIIF Downloader & Studio for working with IIIF manuscripts."
+description = "Scriptoria — a research workbench for IIIF manuscripts."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
@@ -28,8 +28,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/nikazzio/universal-iiif-studio"
-Repository = "https://github.com/nikazzio/universal-iiif-studio"
+Homepage = "https://github.com/nikazzio/scriptoria"
+Repository = "https://github.com/nikazzio/scriptoria"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -147,5 +147,7 @@ insertion_flag = "<!-- version list -->"
 changelog_file = "CHANGELOG.md"
 
 [project.scripts]
+scriptoria = "studio_app:main"
+scriptoria-cli = "universal_iiif_cli.cli:main"
 iiif-studio = "studio_app:main"
 iiif-cli = "universal_iiif_cli.cli:main"

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -8,7 +8,7 @@
     "style": "xml",
     "parsableStyle": true,
     "compress": true,
-    "headerText": "Universal IIIF Downloader & Studio (v0.24.1) – focus on studio_app.py, src/universal_iiif_core/, src/studio_ui/, src/universal_iiif_cli/, docs/, tests/, and AGENTS.md for workflow context; ignore assets/downloads, vault/log caches, and generated binaries.",
+    "headerText": "Scriptoria – focus on studio_app.py, src/universal_iiif_core/, src/studio_ui/, src/universal_iiif_cli/, docs/, tests/, and AGENTS.md for workflow context; ignore assets/downloads, vault/log caches, and generated binaries.",
     "instructionFilePath": "AGENTS.md",
     "fileSummary": true,
     "directoryStructure": true,

--- a/src/studio_app.py
+++ b/src/studio_app.py
@@ -188,7 +188,7 @@ def health():
 
 def main():
     """Punto di ingresso per il comando iiif-studio."""
-    parser = argparse.ArgumentParser(description="Universal IIIF Studio web app")
+    parser = argparse.ArgumentParser(description="Scriptoria web app")
     parser.add_argument(
         "--reload",
         action="store_true",
@@ -197,7 +197,7 @@ def main():
     args = parser.parse_args()
     reload_enabled = bool(args.reload)
 
-    logger.info("🚀 Starting Universal IIIF Studio App (FastHTML + Mirador)")
+    logger.info("🚀 Starting Scriptoria")
     logger.info(f"📍 Downloads directory: {config.get_downloads_dir()}")
     logger.info(
         "Startup mode: %s",

--- a/src/studio_ui/__init__.py
+++ b/src/studio_ui/__init__.py
@@ -1,4 +1,4 @@
-"""FastHTML UI Package - Universal IIIF Downloader.
+"""FastHTML UI package for Scriptoria.
 
 Modern web interface using FastHTML for manuscript viewing and transcription.
 """

--- a/src/studio_ui/components/layout.py
+++ b/src/studio_ui/components/layout.py
@@ -330,8 +330,8 @@ def _sidebar(active_page: str = "") -> Nav:
                 Div(
                     Img(src="/assets/morte_tamburo.png", cls="w-10 h-10 rounded-full border border-white/30 shadow-sm"),
                     Div(
-                        Div("Universal IIIF", cls="text-xl font-bold text-white leading-tight"),
-                        Div("Downloader & Studio", cls="text-xs uppercase tracking-[0.3em] text-gray-400"),
+                        Div("Scriptoria", cls="text-xl font-bold text-white leading-tight"),
+                        Div("IIIF Research Workbench", cls="text-xs uppercase tracking-[0.3em] text-gray-400"),
                         cls="flex flex-col leading-tight sidebar-brand-text",
                     ),
                     cls="flex items-center gap-3",

--- a/src/studio_ui/routes/settings_handlers.py
+++ b/src/studio_ui/routes/settings_handlers.py
@@ -411,7 +411,7 @@ def settings_page(request):
     is_hx = request.headers.get("HX-Request") == "true"
     if is_hx:
         return settings_content()
-    return base_layout(title="Impostazioni - Universal IIIF", content=settings_content(), active_page="settings")
+    return base_layout(title="Impostazioni - Scriptoria", content=settings_content(), active_page="settings")
 
 
 async def save_settings(request):

--- a/src/universal_iiif_cli/__init__.py
+++ b/src/universal_iiif_cli/__init__.py
@@ -1,4 +1,4 @@
-"""CLI package for Universal IIIF Downloader."""
+"""CLI package for Scriptoria."""
 
 from __future__ import annotations
 

--- a/src/universal_iiif_cli/cli.py
+++ b/src/universal_iiif_cli/cli.py
@@ -44,7 +44,7 @@ def wizard_mode():
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Universal IIIF Downloader")
+    parser = argparse.ArgumentParser(description="Scriptoria CLI")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument(
         "url",

--- a/src/universal_iiif_cli/tools/verify_image_processing.py
+++ b/src/universal_iiif_cli/tools/verify_image_processing.py
@@ -32,7 +32,7 @@ def main() -> None:
     region/size transform to ensure the processing pipeline produces a valid
     JPEG output.
     """
-    parser = argparse.ArgumentParser(description="Verify image processing flow for Universal IIIF downloads.")
+    parser = argparse.ArgumentParser(description="Verify image processing flow for Scriptoria downloads.")
     parser.add_argument("--library", default="Vaticana", help="Library folder inside downloads/")
     parser.add_argument("--doc", default="Urb.lat.1779", help="Document identifier (folder name)")
     parser.add_argument("--page", type=int, default=7, help="1-based page index to inspect")

--- a/src/universal_iiif_core/exceptions.py
+++ b/src/universal_iiif_core/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 class UniversalIIIFError(Exception):
-    """Base exception for all Universal IIIF custom exceptions."""
+    """Base exception for all Scriptoria custom exceptions."""
 
 
 class NetworkError(UniversalIIIFError):

--- a/src/universal_iiif_core/export_studio.py
+++ b/src/universal_iiif_core/export_studio.py
@@ -146,7 +146,7 @@ def _add_cover_page(  # noqa: C901
         color=(1, 1, 1),
     )
 
-    subtitle = "Universal IIIF Downloader · PDF Export"
+    subtitle = "Scriptoria · PDF Export"
     page.insert_text(
         fitz.Point(margin_x, 92),
         subtitle,
@@ -219,7 +219,7 @@ def _add_cover_page(  # noqa: C901
     # Footer
     page.insert_text(
         fitz.Point(margin_x, rect.height - 50),
-        f"Generato il {time.strftime('%Y-%m-%d')} · Universal IIIF Downloader",
+        f"Generato il {time.strftime('%Y-%m-%d')} · Scriptoria",
         fontsize=9.5,
         fontname="helv",
         color=(0.45, 0.45, 0.45),


### PR DESCRIPTION
## Rebrand to Scriptoria (#144)

Renames all user-facing references from "Universal IIIF Studio/Downloader" to **Scriptoria**.

### Changes (22 files)
- **pyproject.toml**: description, URLs, new `scriptoria`/`scriptoria-cli` entrypoints (old kept as aliases)
- **README.md**: repo URLs, quickstart, commands
- **UI**: navbar title, settings page title, startup log
- **CLI**: argparse description, package docstrings
- **Core**: PDF export branding (cover + footer), exceptions docstring
- **Docs**: ARCHITECTURE, DOCUMENTAZIONE, wiki pages, HTTP_CLIENT
- **AGENTS.md**: project name, run commands
- **GitHub templates**: issue config URL
- **SVG hero + repomix config**

### Not changed (intentional)
- Python package names (`universal_iiif_core`, `studio_ui`, `universal_iiif_cli`) — too invasive
- CHANGELOG.md — historical entries keep old name
- Old CLI commands (`iiif-studio`, `iiif-cli`) — kept as backward-compat aliases

Closes #144