### PR TITLE
feat(export): UX redesign thumbnail cards and toolbar (#142)

### DIFF
--- a/src/studio_ui/components/layout.py
+++ b/src/studio_ui/components/layout.py
@@ -736,15 +736,12 @@ def _style_tag():
         "gap: 0.35rem; width: 100%; min-width: 0; }\n",
         ".studio-thumb-action-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; "
         "white-space: nowrap; line-height: 1; }\n",
-        ".studio-thumb-highres-btn { white-space: nowrap; font-size: 0.72rem !important; "
-        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
-        "overflow: hidden; }\n",
         ".studio-thumb-stitch-btn { white-space: nowrap; font-size: 0.72rem !important; "
         "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
         "overflow: hidden; }\n",
-        ".studio-thumb-opt-btn { white-space: nowrap; font-size: 0.72rem !important; "
-        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
-        "overflow: hidden; }\n",
+        ".studio-thumb-menu-toggle { font-size: 0.82rem !important; padding: 0.34rem 0.5rem !important; "
+        "line-height: 1; min-width: 0; }\n",
+        ".studio-thumb-dropdown { font-size: 0.72rem; }\n",
         ".studio-thumb-progress { --progress: 0%; width: 0.88rem; height: 0.88rem; border-radius: 999px; "
         "flex: 0 0 0.88rem; display: inline-block; transform-origin: 50% 50%; will-change: transform; "
         "background: conic-gradient(var(--app-accent) var(--progress), rgba(148, 163, 184, 0.28) 0); "

--- a/src/studio_ui/components/layout.py
+++ b/src/studio_ui/components/layout.py
@@ -736,12 +736,15 @@ def _style_tag():
         "gap: 0.35rem; width: 100%; min-width: 0; }\n",
         ".studio-thumb-action-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; "
         "white-space: nowrap; line-height: 1; }\n",
-        ".studio-thumb-stitch-btn { white-space: nowrap; font-size: 0.72rem !important; "
+        ".studio-thumb-download-btn { white-space: nowrap; font-size: 0.72rem !important; "
         "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
         "overflow: hidden; }\n",
-        ".studio-thumb-menu-toggle { font-size: 0.82rem !important; padding: 0.34rem 0.5rem !important; "
-        "line-height: 1; min-width: 0; }\n",
-        ".studio-thumb-dropdown { font-size: 0.72rem; }\n",
+        ".studio-thumb-highres-btn { white-space: nowrap; font-size: 0.72rem !important; "
+        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
+        "overflow: hidden; }\n",
+        ".studio-thumb-opt-btn { white-space: nowrap; font-size: 0.72rem !important; "
+        "padding: 0.34rem 0.44rem !important; flex: 1 1 0; min-width: 0; justify-content: flex-start !important; "
+        "overflow: hidden; }\n",
         ".studio-thumb-progress { --progress: 0%; width: 0.88rem; height: 0.88rem; border-radius: 999px; "
         "flex: 0 0 0.88rem; display: inline-block; transform-origin: 50% 50%; will-change: transform; "
         "background: conic-gradient(var(--app-accent) var(--progress), rgba(148, 163, 184, 0.28) 0); "

--- a/src/studio_ui/components/studio/export/pages.py
+++ b/src/studio_ui/components/studio/export/pages.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
-from fasthtml.common import H3, Button, Div, P, Span
+from fasthtml.common import H3, Button, Div, Input, P, Span
 
 from .pdf_inventory import _bytes_label
 from .thumbnails import render_export_thumbnails_loading_shell, render_export_thumbnails_panel
@@ -102,6 +102,43 @@ def _render_export_pages_subtab(
                 thumb_page_size=thumb_page_size,
             ),
             cls="space-y-2",
+        ),
+        Div(
+            Div(
+                Button(
+                    "☑ Tutte",
+                    type="button",
+                    id="studio-export-pages-select-all",
+                    cls="app-btn app-btn-neutral text-xs",
+                ),
+                Button(
+                    "☐ Nessuna",
+                    type="button",
+                    id="studio-export-pages-clear",
+                    cls="app-btn app-btn-neutral text-xs",
+                ),
+                Div(
+                    Input(
+                        type="text",
+                        id="studio-export-pages-range",
+                        placeholder="es. 1-10,12,20-25",
+                        cls="app-field text-xs w-36",
+                    ),
+                    Button(
+                        "Applica",
+                        type="button",
+                        id="studio-export-pages-apply-range",
+                        cls="app-btn app-btn-accent text-xs",
+                    ),
+                    cls="flex items-center gap-1.5",
+                ),
+                Span(
+                    "0 pagine selezionate",
+                    cls="studio-export-selected-count text-xs text-slate-500 dark:text-slate-400",
+                ),
+                cls="flex flex-wrap items-center gap-2",
+            ),
+            cls=("p-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80"),
         ),
         Div(
             Div(

--- a/src/studio_ui/components/studio/export/pages.py
+++ b/src/studio_ui/components/studio/export/pages.py
@@ -168,6 +168,7 @@ def _render_export_pages_subtab(
                     hx_indicator="#studio-export-optimize-selected-indicator",
                     hx_target="#studio-export-panel",
                     hx_swap="outerHTML",
+                    hx_disabled_elt="this",
                     cls="app-btn app-btn-neutral",
                 ),
                 Button(
@@ -188,6 +189,7 @@ def _render_export_pages_subtab(
                     hx_indicator="#studio-export-optimize-all-indicator",
                     hx_target="#studio-export-panel",
                     hx_swap="outerHTML",
+                    hx_disabled_elt="this",
                     cls="app-btn app-btn-neutral",
                 ),
                 cls="flex flex-wrap items-center gap-2",

--- a/src/studio_ui/components/studio/export/pages.py
+++ b/src/studio_ui/components/studio/export/pages.py
@@ -23,18 +23,21 @@ def render_export_pages_summary(
     attrs = {"id": "studio-export-pages-summary"}
     if hx_swap_oob:
         attrs["hx_swap_oob"] = hx_swap_oob
+    files_count = int(scan_summary.get("files_count") or 0)
+    bytes_total = int(scan_summary.get("bytes_total") or 0)
+    bytes_avg = int(scan_summary.get("bytes_avg") or 0)
+    bytes_max = int(scan_summary.get("bytes_max") or 0)
     return Div(
         Span(
-            (
-                f"Pagine {thumb_total_pages} · File {int(scan_summary.get('files_count') or 0)} · "
-                f"Locale {_bytes_label(int(scan_summary.get('bytes_total') or 0))} · "
-                f"Media {_bytes_label(int(scan_summary.get('bytes_avg') or 0))} · "
-                f"Max {_bytes_label(int(scan_summary.get('bytes_max') or 0))}"
-            ),
+            f"{thumb_total_pages} pagine · {files_count} file scaricati · {_bytes_label(bytes_total)} totali",
             cls="text-xs font-mono text-slate-700 dark:text-slate-200",
         ),
         Span(
-            f"Thumb page {thumb_page}/{thumb_page_count} · {thumb_page_size} per pagina",
+            (
+                f"Media {_bytes_label(bytes_avg)}/file · "
+                f"Max {_bytes_label(bytes_max)}/file · "
+                f"Miniature: pag. {thumb_page} di {thumb_page_count}, {thumb_page_size}/pag."
+            ),
             cls="text-[11px] text-slate-500 dark:text-slate-400",
         ),
         cls=(
@@ -97,7 +100,10 @@ def _render_export_pages_subtab(
             cls="px-1",
         )
         if has_optimize_feedback
-        else None
+        else Span(
+            "Nessuna ottimizzazione eseguita.",
+            cls="text-[11px] text-slate-400 dark:text-slate-500 px-1",
+        )
     )
 
     return Div(
@@ -131,57 +137,38 @@ def _render_export_pages_subtab(
                     id="studio-export-pages-clear",
                     cls="app-btn app-btn-neutral text-xs",
                 ),
-                Div(
-                    Input(
-                        type="text",
-                        id="studio-export-pages-range",
-                        placeholder="es. 1-10,12,20-25",
-                        cls="app-field text-xs w-36",
-                    ),
-                    Button(
-                        "Applica",
-                        type="button",
-                        id="studio-export-pages-apply-range",
-                        cls="app-btn app-btn-accent text-xs",
-                    ),
-                    cls="flex items-center gap-1.5",
-                ),
                 Span(
-                    "0 pagine selezionate",
-                    cls="studio-export-selected-count text-xs text-slate-500 dark:text-slate-400",
+                    "0 selezionate",
+                    cls="studio-export-selected-count text-xs font-mono text-slate-600 dark:text-slate-300",
                 ),
                 cls="flex flex-wrap items-center gap-2",
             ),
-            # Row 2: Bulk actions
+            # Row 2: Range selection
             Div(
-                Span("Azioni:", cls="text-[11px] font-semibold text-slate-600 dark:text-slate-300"),
-                Button(
-                    Div(
-                        Span("⚙ Ottimizza sel."),
-                        Span(
-                            "…",
-                            id="studio-export-optimize-selected-indicator",
-                            cls="htmx-indicator text-xs",
-                        ),
-                        cls="flex items-center gap-1",
-                    ),
-                    type="button",
-                    id="studio-export-optimize-selected-btn",
-                    hx_post=optimize_url,
-                    hx_vals='{"optimize_scope":"selected"}',
-                    hx_include="#studio-export-selected-pages,#studio-export-thumb-page,#studio-export-page-size",
-                    hx_indicator="#studio-export-optimize-selected-indicator",
-                    hx_target="#studio-export-panel",
-                    hx_swap="outerHTML",
-                    hx_disabled_elt="this",
-                    cls="app-btn app-btn-neutral text-xs",
+                Span("Range:", cls="text-[11px] text-slate-500 dark:text-slate-400"),
+                Input(
+                    type="text",
+                    id="studio-export-pages-range",
+                    placeholder="es. 1-10, 12, 20-25",
+                    maxlength="100",
+                    cls="app-field text-xs w-36",
                 ),
                 Button(
+                    "Seleziona range",
+                    type="button",
+                    id="studio-export-pages-apply-range",
+                    cls="app-btn app-btn-neutral text-xs",
+                ),
+                cls="flex flex-wrap items-center gap-1.5",
+            ),
+            # Row 3: Optimize + feedback
+            Div(
+                Button(
                     Div(
-                        Span("⚙ Ottimizza tutte"),
+                        Span("⚙ Ottimizza"),
                         Span(
                             "…",
-                            id="studio-export-optimize-all-indicator",
+                            id="studio-export-optimize-indicator",
                             cls="htmx-indicator text-xs",
                         ),
                         cls="flex items-center gap-1",
@@ -189,17 +176,37 @@ def _render_export_pages_subtab(
                     type="button",
                     id="studio-export-optimize-btn",
                     hx_post=optimize_url,
-                    hx_vals='{"optimize_scope":"all"}',
-                    hx_include="#studio-export-selected-pages,#studio-export-thumb-page,#studio-export-page-size",
-                    hx_indicator="#studio-export-optimize-all-indicator",
+                    hx_vals='{"optimize_scope":"selected"}',
+                    hx_include=("#studio-export-selected-pages,#studio-export-thumb-page,#studio-export-page-size"),
+                    hx_indicator="#studio-export-optimize-indicator",
                     hx_target="#studio-export-panel",
                     hx_swap="outerHTML",
                     hx_disabled_elt="this",
                     cls="app-btn app-btn-neutral text-xs",
+                    title="Comprimi i file delle pagine selezionate",
                 ),
+                optimize_feedback_el,
                 cls="flex flex-wrap items-center gap-2",
             ),
-            *([] if optimize_feedback_el is None else [optimize_feedback_el]),
+            # Legenda pulsanti card
+            Div(
+                P(
+                    Span("⬇ Scarica", cls="font-semibold"),
+                    " — riscarica con la strategia progressiva del volume (es. 3000 → 1740 → max, con stitching)",
+                    cls="text-[11px] font-mono text-slate-500 dark:text-slate-400",
+                ),
+                P(
+                    Span("⬇ Hi", cls="font-semibold"),
+                    " — fetch diretto alla risoluzione massima dichiarata dalla biblioteca, senza fallback",
+                    cls="text-[11px] font-mono text-slate-500 dark:text-slate-400",
+                ),
+                P(
+                    Span("⚙ Opt", cls="font-semibold"),
+                    " — comprimi il file già scaricato in locale senza perdita di qualità visiva",
+                    cls="text-[11px] font-mono text-slate-500 dark:text-slate-400",
+                ),
+                cls="space-y-0.5",
+            ),
             cls=(
                 "space-y-2 p-2.5 rounded-xl border border-slate-200 dark:border-slate-700 "
                 "bg-white/80 dark:bg-slate-900/80"
@@ -229,9 +236,9 @@ def _render_export_pages_subtab(
         ),
         Div(
             Span(
-                "0 pagine selezionate",
+                "0 selezionate",
                 id="studio-export-selected-count",
-                cls="studio-export-selected-count text-xs text-slate-500 dark:text-slate-400",
+                cls="studio-export-selected-count text-xs font-mono text-slate-600 dark:text-slate-300",
             ),
             open_output_btn,
             cls=(

--- a/src/studio_ui/components/studio/export/pages.py
+++ b/src/studio_ui/components/studio/export/pages.py
@@ -67,10 +67,7 @@ def _render_export_pages_subtab(
     optimized_pages = int(feedback.get("optimized_pages") or 0)
     saved_bytes = int(feedback.get("bytes_saved") or 0)
     errors = int(feedback.get("errors") or 0)
-    before_bytes = int(feedback.get("bytes_before") or 0)
-    after_bytes = int(feedback.get("bytes_after") or 0)
     savings_percent = float(feedback.get("savings_percent") or 0.0)
-    optimized_at = str(feedback.get("optimized_at") or "")
     skipped_pages = int(feedback.get("skipped_pages") or 0)
     scope = str(feedback.get("scope") or "all").strip().lower()
     optimize_url = (
@@ -84,14 +81,30 @@ def _render_export_pages_subtab(
         cls="app-btn app-btn-accent",
     )
 
+    has_optimize_feedback = optimized_pages > 0 or saved_bytes > 0 or errors > 0
+    optimize_feedback_el = (
+        Div(
+            Span(
+                (
+                    f"Ultimo: ({'sel.' if scope == 'selected' else 'tutte'}) "
+                    f"{optimized_pages} pag., "
+                    f"−{_bytes_label(saved_bytes)} ({savings_percent:.1f}%)"
+                    + (f", {errors} err." if errors else "")
+                    + (f", {skipped_pages} skip." if skipped_pages > 0 else "")
+                ),
+                cls="text-[11px] text-slate-600 dark:text-slate-300",
+            ),
+            cls="px-1",
+        )
+        if has_optimize_feedback
+        else None
+    )
+
     return Div(
         Div(
             H3("Workspace Immagini", cls="text-sm font-semibold text-slate-900 dark:text-slate-100"),
             P(
-                (
-                    "Gestisci miniature, high-res e ottimizzazione locale. "
-                    "Le miniature della pagina visibile vengono create on-demand al primo accesso."
-                ),
+                "Gestisci miniature, scaricamento e ottimizzazione locale.",
                 cls="text-xs text-slate-500 dark:text-slate-400",
             ),
             render_export_pages_summary(
@@ -104,6 +117,7 @@ def _render_export_pages_subtab(
             cls="space-y-2",
         ),
         Div(
+            # Row 1: Selection controls
             Div(
                 Button(
                     "☑ Tutte",
@@ -138,21 +152,12 @@ def _render_export_pages_subtab(
                 ),
                 cls="flex flex-wrap items-center gap-2",
             ),
-            cls=("p-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80"),
-        ),
-        Div(
+            # Row 2: Bulk actions
             Div(
-                H3("Ottimizzazione Scans Locali", cls="text-sm font-semibold text-slate-900 dark:text-slate-100"),
-                P(
-                    "Riduci il peso dei file locali. Usa selezione o tutto l'item.",
-                    cls="text-xs text-slate-500 dark:text-slate-400",
-                ),
-                cls="space-y-1",
-            ),
-            Div(
+                Span("Azioni:", cls="text-[11px] font-semibold text-slate-600 dark:text-slate-300"),
                 Button(
                     Div(
-                        Span("Ottimizza selezione"),
+                        Span("⚙ Ottimizza sel."),
                         Span(
                             "…",
                             id="studio-export-optimize-selected-indicator",
@@ -169,11 +174,11 @@ def _render_export_pages_subtab(
                     hx_target="#studio-export-panel",
                     hx_swap="outerHTML",
                     hx_disabled_elt="this",
-                    cls="app-btn app-btn-neutral",
+                    cls="app-btn app-btn-neutral text-xs",
                 ),
                 Button(
                     Div(
-                        Span("Ottimizza tutte"),
+                        Span("⚙ Ottimizza tutte"),
                         Span(
                             "…",
                             id="studio-export-optimize-all-indicator",
@@ -190,38 +195,15 @@ def _render_export_pages_subtab(
                     hx_target="#studio-export-panel",
                     hx_swap="outerHTML",
                     hx_disabled_elt="this",
-                    cls="app-btn app-btn-neutral",
+                    cls="app-btn app-btn-neutral text-xs",
                 ),
                 cls="flex flex-wrap items-center gap-2",
             ),
-            (
-                Div(
-                    Span(
-                        (
-                            f"Ultimo run: ({'selezione' if scope == 'selected' else 'globale'}) "
-                            f"{optimized_pages} pagine ottimizzate, "
-                            f"risparmio {_bytes_label(saved_bytes)} ({savings_percent:.2f}%), errori {errors}."
-                            + (f" Skippate {skipped_pages}." if skipped_pages > 0 else "")
-                        ),
-                        cls="text-xs text-slate-700 dark:text-slate-200",
-                    ),
-                    Span(
-                        f"Prima {_bytes_label(before_bytes)} · Dopo {_bytes_label(after_bytes)}"
-                        + (f" · {optimized_at}" if optimized_at else ""),
-                        cls="text-[11px] text-slate-500 dark:text-slate-400",
-                    ),
-                    cls=(
-                        "flex flex-col gap-1 p-2.5 rounded-lg border border-slate-200 dark:border-slate-700 "
-                        "bg-white dark:bg-slate-900"
-                    ),
-                )
-                if optimized_pages > 0 or saved_bytes > 0 or errors > 0
-                else Div(
-                    "Nessuna ottimizzazione registrata per questo item.",
-                    cls="text-xs text-slate-500 dark:text-slate-400",
-                ),
+            *([] if optimize_feedback_el is None else [optimize_feedback_el]),
+            cls=(
+                "space-y-2 p-2.5 rounded-xl border border-slate-200 dark:border-slate-700 "
+                "bg-white/80 dark:bg-slate-900/80"
             ),
-            cls=("space-y-2 p-3 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900"),
         ),
         Div(
             render_export_thumbnails_loading_shell(

--- a/src/studio_ui/components/studio/export/tab_script.py
+++ b/src/studio_ui/components/studio/export/tab_script.py
@@ -508,6 +508,43 @@ def _export_tab_script() -> Script:
                     applySelectionToVisible(panel);
                     syncSelectionStore(panel);
 
+                    // Dropdown menu toggle for per-card action menus
+                    panel.querySelectorAll('.studio-thumb-menu-toggle').forEach((toggle) => {
+                        if (toggle.dataset.bound === '1') return;
+                        toggle.dataset.bound = '1';
+                        toggle.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            const menuId = toggle.dataset.menu;
+                            if (!menuId) return;
+                            const menu = document.getElementById(menuId);
+                            if (!menu) return;
+                            const isOpen = !menu.classList.contains('hidden');
+                            // Close all other menus first
+                            panel.querySelectorAll('.studio-thumb-dropdown').forEach((m) => {
+                                m.classList.add('hidden');
+                            });
+                            panel.querySelectorAll('.studio-thumb-menu-toggle').forEach((t) => {
+                                t.setAttribute('aria-expanded', 'false');
+                            });
+                            if (!isOpen) {
+                                menu.classList.remove('hidden');
+                                toggle.setAttribute('aria-expanded', 'true');
+                            }
+                        });
+                    });
+                    // Close dropdown on outside click
+                    if (!panel.dataset.menuClickBound) {
+                        panel.dataset.menuClickBound = '1';
+                        document.addEventListener('click', () => {
+                            panel.querySelectorAll('.studio-thumb-dropdown').forEach((m) => {
+                                m.classList.add('hidden');
+                            });
+                            panel.querySelectorAll('.studio-thumb-menu-toggle').forEach((t) => {
+                                t.setAttribute('aria-expanded', 'false');
+                            });
+                        });
+                    }
+
                     if (includeCoverCheckbox && includeCoverHidden && includeCoverCheckbox.dataset.bound !== '1') {
                         includeCoverCheckbox.dataset.bound = '1';
                         includeCoverCheckbox.addEventListener('change', () => {

--- a/src/studio_ui/components/studio/export/tab_script.py
+++ b/src/studio_ui/components/studio/export/tab_script.py
@@ -448,6 +448,46 @@ def _export_tab_script() -> Script:
                         });
                     }
 
+                    // Pages-toolbar selection buttons (mirror of Build tab controls)
+                    const pagesAllBtn = panel.querySelector('#studio-export-pages-select-all');
+                    const pagesClearBtn = panel.querySelector('#studio-export-pages-clear');
+                    const pagesRangeInput = panel.querySelector('#studio-export-pages-range');
+                    const pagesRangeBtn = panel.querySelector('#studio-export-pages-apply-range');
+
+                    if (pagesAllBtn && pagesAllBtn.dataset.bound !== '1') {
+                        pagesAllBtn.dataset.bound = '1';
+                        pagesAllBtn.addEventListener('click', () => {
+                            if (!hidden) return;
+                            hidden.value = serializeSelection(availablePages(panel));
+                            setSelectionScope('all');
+                            applySelectionToVisible(panel);
+                            syncSelectionStore(panel);
+                        });
+                    }
+
+                    if (pagesClearBtn && pagesClearBtn.dataset.bound !== '1') {
+                        pagesClearBtn.dataset.bound = '1';
+                        pagesClearBtn.addEventListener('click', () => {
+                            if (!hidden) return;
+                            hidden.value = '';
+                            setSelectionScope('custom');
+                            applySelectionToVisible(panel);
+                            syncSelectionStore(panel);
+                        });
+                    }
+
+                    if (pagesRangeBtn && pagesRangeBtn.dataset.bound !== '1') {
+                        pagesRangeBtn.dataset.bound = '1';
+                        pagesRangeBtn.addEventListener('click', () => {
+                            if (!hidden || !pagesRangeInput) return;
+                            const parsed = parseSelection(pagesRangeInput.value || '');
+                            hidden.value = serializeSelection(parsed);
+                            setSelectionScope('custom');
+                            applySelectionToVisible(panel);
+                            syncSelectionStore(panel);
+                        });
+                    }
+
                     if (optimizeBtn && optimizeBtn.dataset.bound !== '1') {
                         optimizeBtn.dataset.bound = '1';
                         optimizeBtn.addEventListener('click', () => {

--- a/src/studio_ui/components/studio/export/tab_script.py
+++ b/src/studio_ui/components/studio/export/tab_script.py
@@ -55,7 +55,7 @@ def _export_tab_script() -> Script:
                     const selected = parseSelection(hidden.value);
                     const counters = panel.querySelectorAll('.studio-export-selected-count');
                     counters.forEach((node) => {
-                        node.textContent = `${selected.size} pagine selezionate`;
+                        node.textContent = `${selected.size} selezionate`;
                     });
                 }
 
@@ -158,7 +158,6 @@ def _export_tab_script() -> Script:
                     const subtabPages = panel.querySelector('#studio-export-subtab-pages');
                     const subtabJobs = panel.querySelector('#studio-export-subtab-jobs');
                     const optimizeBtn = panel.querySelector('#studio-export-optimize-btn');
-                    const optimizeSelectedBtn = panel.querySelector('#studio-export-optimize-selected-btn');
                     const openBuildBtn = panel.querySelector('#studio-export-open-build');
                     const openPagesBtn = panel.querySelector('#studio-export-open-pages-custom');
                     const buildSubtabHidden = panel.querySelector('#studio-export-build-subtab-state');
@@ -414,91 +413,54 @@ def _export_tab_script() -> Script:
                         });
                     }
 
-                    if (rangeBtn && rangeBtn.dataset.bound !== '1') {
-                        rangeBtn.dataset.bound = '1';
-                        rangeBtn.addEventListener('click', () => {
-                            if (!hidden || !rangeInput) return;
-                            const parsed = parseSelection(rangeInput.value || '');
+                    // Shared selection helpers — used by both Build tab and Pages toolbar
+                    function bindBtn(el, fn) {
+                        if (el && el.dataset.bound !== '1') {
+                            el.dataset.bound = '1';
+                            el.addEventListener('click', fn);
+                        }
+                    }
+                    const selectAllHandler = () => {
+                        if (!hidden) return;
+                        hidden.value = serializeSelection(availablePages(panel));
+                        setSelectionScope('all');
+                        applySelectionToVisible(panel);
+                        syncSelectionStore(panel);
+                    };
+                    const clearHandler = () => {
+                        if (!hidden) return;
+                        hidden.value = '';
+                        setSelectionScope('custom');
+                        applySelectionToVisible(panel);
+                        syncSelectionStore(panel);
+                    };
+                    function applyRangeHandler(input) {
+                        return () => {
+                            if (!hidden || !input) return;
+                            const parsed = parseSelection(input.value || '');
                             hidden.value = serializeSelection(parsed);
                             setSelectionScope('custom');
                             applySelectionToVisible(panel);
                             syncSelectionStore(panel);
-                        });
+                        };
                     }
 
-                    if (allBtn && allBtn.dataset.bound !== '1') {
-                        allBtn.dataset.bound = '1';
-                        allBtn.addEventListener('click', () => {
-                            if (!hidden) return;
-                            hidden.value = serializeSelection(availablePages(panel));
-                            setSelectionScope('all');
-                            applySelectionToVisible(panel);
-                            syncSelectionStore(panel);
-                        });
-                    }
+                    // Build tab controls
+                    bindBtn(allBtn, selectAllHandler);
+                    bindBtn(clearBtn, clearHandler);
+                    bindBtn(rangeBtn, applyRangeHandler(rangeInput));
 
-                    if (clearBtn && clearBtn.dataset.bound !== '1') {
-                        clearBtn.dataset.bound = '1';
-                        clearBtn.addEventListener('click', () => {
-                            if (!hidden) return;
-                            hidden.value = '';
-                            setSelectionScope('custom');
-                            applySelectionToVisible(panel);
-                            syncSelectionStore(panel);
-                        });
-                    }
-
-                    // Pages-toolbar selection buttons (mirror of Build tab controls)
-                    const pagesAllBtn = panel.querySelector('#studio-export-pages-select-all');
-                    const pagesClearBtn = panel.querySelector('#studio-export-pages-clear');
+                    // Pages toolbar controls
                     const pagesRangeInput = panel.querySelector('#studio-export-pages-range');
+                    bindBtn(panel.querySelector('#studio-export-pages-select-all'), selectAllHandler);
+                    bindBtn(panel.querySelector('#studio-export-pages-clear'), clearHandler);
                     const pagesRangeBtn = panel.querySelector('#studio-export-pages-apply-range');
-
-                    if (pagesAllBtn && pagesAllBtn.dataset.bound !== '1') {
-                        pagesAllBtn.dataset.bound = '1';
-                        pagesAllBtn.addEventListener('click', () => {
-                            if (!hidden) return;
-                            hidden.value = serializeSelection(availablePages(panel));
-                            setSelectionScope('all');
-                            applySelectionToVisible(panel);
-                            syncSelectionStore(panel);
-                        });
-                    }
-
-                    if (pagesClearBtn && pagesClearBtn.dataset.bound !== '1') {
-                        pagesClearBtn.dataset.bound = '1';
-                        pagesClearBtn.addEventListener('click', () => {
-                            if (!hidden) return;
-                            hidden.value = '';
-                            setSelectionScope('custom');
-                            applySelectionToVisible(panel);
-                            syncSelectionStore(panel);
-                        });
-                    }
-
-                    if (pagesRangeBtn && pagesRangeBtn.dataset.bound !== '1') {
-                        pagesRangeBtn.dataset.bound = '1';
-                        pagesRangeBtn.addEventListener('click', () => {
-                            if (!hidden || !pagesRangeInput) return;
-                            const parsed = parseSelection(pagesRangeInput.value || '');
-                            hidden.value = serializeSelection(parsed);
-                            setSelectionScope('custom');
-                            applySelectionToVisible(panel);
-                            syncSelectionStore(panel);
-                        });
-                    }
+                    bindBtn(pagesRangeBtn, applyRangeHandler(pagesRangeInput));
 
                     if (optimizeBtn && optimizeBtn.dataset.bound !== '1') {
                         optimizeBtn.dataset.bound = '1';
                         optimizeBtn.addEventListener('click', () => {
                             if (subtabStateHidden) subtabStateHidden.value = 'pages';
-                        });
-                    }
-                    if (optimizeSelectedBtn && optimizeSelectedBtn.dataset.bound !== '1') {
-                        optimizeSelectedBtn.dataset.bound = '1';
-                        optimizeSelectedBtn.addEventListener('click', () => {
-                            if (subtabStateHidden) subtabStateHidden.value = 'pages';
-                            setSelectionScope('custom');
                         });
                     }
 
@@ -507,43 +469,6 @@ def _export_tab_script() -> Script:
                     });
                     applySelectionToVisible(panel);
                     syncSelectionStore(panel);
-
-                    // Dropdown menu toggle for per-card action menus
-                    panel.querySelectorAll('.studio-thumb-menu-toggle').forEach((toggle) => {
-                        if (toggle.dataset.bound === '1') return;
-                        toggle.dataset.bound = '1';
-                        toggle.addEventListener('click', (e) => {
-                            e.stopPropagation();
-                            const menuId = toggle.dataset.menu;
-                            if (!menuId) return;
-                            const menu = document.getElementById(menuId);
-                            if (!menu) return;
-                            const isOpen = !menu.classList.contains('hidden');
-                            // Close all other menus first
-                            panel.querySelectorAll('.studio-thumb-dropdown').forEach((m) => {
-                                m.classList.add('hidden');
-                            });
-                            panel.querySelectorAll('.studio-thumb-menu-toggle').forEach((t) => {
-                                t.setAttribute('aria-expanded', 'false');
-                            });
-                            if (!isOpen) {
-                                menu.classList.remove('hidden');
-                                toggle.setAttribute('aria-expanded', 'true');
-                            }
-                        });
-                    });
-                    // Close dropdown on outside click
-                    if (!panel.dataset.menuClickBound) {
-                        panel.dataset.menuClickBound = '1';
-                        document.addEventListener('click', () => {
-                            panel.querySelectorAll('.studio-thumb-dropdown').forEach((m) => {
-                                m.classList.add('hidden');
-                            });
-                            panel.querySelectorAll('.studio-thumb-menu-toggle').forEach((t) => {
-                                t.setAttribute('aria-expanded', 'false');
-                            });
-                        });
-                    }
 
                     if (includeCoverCheckbox && includeCoverHidden && includeCoverCheckbox.dataset.bound !== '1') {
                         includeCoverCheckbox.dataset.bound = '1';

--- a/src/studio_ui/components/studio/export/thumbnails.py
+++ b/src/studio_ui/components/studio/export/thumbnails.py
@@ -121,32 +121,10 @@ def render_export_thumbnail_card(
         f"/api/studio/export/page_optimize?doc_id={encoded_doc}&library={encoded_lib}"
         f"&page={page}&thumb_page={thumb_page}&page_size={page_size}"
     )
-    # Consolidated progress: pick the active one for the primary indicator
-    active_progress_cls = (
-        hi_progress_cls
-        if hi_busy
-        else stitch_progress_cls
-        if stitch_busy
-        else opt_progress_cls
-        if opt_busy
-        else "studio-thumb-progress-idle"
-    )
-    active_progress_pct = (
-        hi_progress_percent
-        if hi_busy
-        else stitch_progress_percent
-        if stitch_busy
-        else opt_progress_percent
-        if opt_busy
-        else 0
-    )
-
     card_id = _thumbnail_card_id(page)
     card_attrs = {"id": card_id}
     if hx_swap_oob:
         card_attrs["hx_swap_oob"] = hx_swap_oob
-
-    menu_id = f"studio-thumb-menu-{page}"
 
     return Div(
         select_btn,
@@ -173,16 +151,13 @@ def render_export_thumbnail_card(
             ),
             Div(
                 Button(
-                    Div(
-                        Span("⬇ Scarica", cls="studio-thumb-action-label text-[11px] font-semibold"),
-                        Span(
-                            "",
-                            id=f"studio-thumb-progress-stitch-{page}",
-                            cls=f"studio-thumb-progress {active_progress_cls}",
-                            style=f"--progress:{active_progress_pct}%;",
-                            aria_hidden="true",
-                        ),
-                        cls="studio-thumb-action-inner",
+                    "⬇",
+                    Span(
+                        "",
+                        id=f"studio-thumb-progress-stitch-{page}",
+                        cls=f"studio-thumb-progress {stitch_progress_cls}",
+                        style=f"--progress:{stitch_progress_percent}%;",
+                        aria_hidden="true",
                     ),
                     type="button",
                     hx_post=stitch_url,
@@ -191,75 +166,52 @@ def render_export_thumbnail_card(
                     hx_target=f"#{card_id}",
                     hx_swap="outerHTML",
                     disabled=is_busy,
-                    cls="app-btn app-btn-neutral studio-thumb-stitch-btn",
+                    cls="app-btn app-btn-neutral studio-thumb-download-btn",
                     data_page=str(page),
-                    title="Scarica con strategia standard del volume",
+                    aria_label="Scarica",
+                    title="Scarica — strategia progressiva del volume (3000 → 1740 → max, con stitching se necessario)",
                 ),
-                Div(
-                    Button(
-                        "⋯",
-                        type="button",
-                        cls=("app-btn app-btn-neutral studio-thumb-menu-toggle text-sm font-bold px-2 py-1"),
-                        disabled=is_busy,
-                        data_menu=menu_id,
-                        aria_expanded="false",
-                        title="Altre azioni",
+                Button(
+                    "⬇",
+                    Span(
+                        "",
+                        id=f"studio-thumb-progress-hi-{page}",
+                        cls=f"studio-thumb-progress {hi_progress_cls}",
+                        style=f"--progress:{hi_progress_percent}%;",
+                        aria_hidden="true",
                     ),
-                    Div(
-                        Button(
-                            Div(
-                                Span("⬇ Hi-res", cls="text-[11px] font-semibold"),
-                                Span(
-                                    "",
-                                    id=f"studio-thumb-progress-hi-{page}",
-                                    cls=f"studio-thumb-progress {hi_progress_cls}",
-                                    style=f"--progress:{hi_progress_percent}%;",
-                                    aria_hidden="true",
-                                ),
-                                cls="flex items-center justify-between gap-2 w-full",
-                            ),
-                            type="button",
-                            hx_post=highres_url,
-                            hx_include="#studio-export-thumb-page,#studio-export-page-size",
-                            hx_indicator=f"#studio-thumb-progress-hi-{page}",
-                            hx_target=f"#{card_id}",
-                            hx_swap="outerHTML",
-                            disabled=is_busy,
-                            cls="app-btn app-btn-neutral w-full text-left",
-                            data_page=str(page),
-                            title="Fetch diretto max risoluzione, senza fallback stitching",
-                        ),
-                        Button(
-                            Div(
-                                Span("⚙ Ottimizza", cls="text-[11px] font-semibold"),
-                                Span(
-                                    "",
-                                    id=f"studio-thumb-progress-opt-{page}",
-                                    cls=f"studio-thumb-progress {opt_progress_cls}",
-                                    style=f"--progress:{opt_progress_percent}%;",
-                                    aria_hidden="true",
-                                ),
-                                cls="flex items-center justify-between gap-2 w-full",
-                            ),
-                            type="button",
-                            hx_post=optimize_url,
-                            hx_include="#studio-export-thumb-page,#studio-export-page-size",
-                            hx_indicator=f"#studio-thumb-progress-opt-{page}",
-                            hx_target=f"#{card_id}",
-                            hx_swap="outerHTML",
-                            disabled=is_busy,
-                            cls="app-btn app-btn-neutral w-full text-left",
-                            data_page=str(page),
-                            title="Ottimizza solo questa pagina localmente",
-                        ),
-                        id=menu_id,
-                        cls=(
-                            "studio-thumb-dropdown hidden absolute right-0 top-full mt-1 z-20 "
-                            "flex flex-col gap-1 p-1.5 rounded-lg border border-slate-200 dark:border-slate-700 "
-                            "bg-white dark:bg-slate-900 shadow-lg min-w-[8rem]"
-                        ),
+                    type="button",
+                    hx_post=highres_url,
+                    hx_include="#studio-export-thumb-page,#studio-export-page-size",
+                    hx_indicator=f"#studio-thumb-progress-hi-{page}",
+                    hx_target=f"#{card_id}",
+                    hx_swap="outerHTML",
+                    disabled=is_busy,
+                    cls="app-btn app-btn-neutral studio-thumb-highres-btn",
+                    data_page=str(page),
+                    aria_label="Hi-res",
+                    title="Hi-res — fetch diretto alla risoluzione massima dalla biblioteca, senza fallback",
+                ),
+                Button(
+                    "⚙",
+                    Span(
+                        "",
+                        id=f"studio-thumb-progress-opt-{page}",
+                        cls=f"studio-thumb-progress {opt_progress_cls}",
+                        style=f"--progress:{opt_progress_percent}%;",
+                        aria_hidden="true",
                     ),
-                    cls="relative",
+                    type="button",
+                    hx_post=optimize_url,
+                    hx_include="#studio-export-thumb-page,#studio-export-page-size",
+                    hx_indicator=f"#studio-thumb-progress-opt-{page}",
+                    hx_target=f"#{card_id}",
+                    hx_swap="outerHTML",
+                    disabled=is_busy,
+                    cls="app-btn app-btn-neutral studio-thumb-opt-btn",
+                    data_page=str(page),
+                    aria_label="Ottimizza",
+                    title="Opt — comprimi il file locale senza perdita di qualità visiva",
                 ),
                 cls="studio-thumb-action",
             ),

--- a/src/studio_ui/components/studio/export/thumbnails.py
+++ b/src/studio_ui/components/studio/export/thumbnails.py
@@ -121,10 +121,33 @@ def render_export_thumbnail_card(
         f"/api/studio/export/page_optimize?doc_id={encoded_doc}&library={encoded_lib}"
         f"&page={page}&thumb_page={thumb_page}&page_size={page_size}"
     )
+    # Consolidated progress: pick the active one for the primary indicator
+    active_progress_cls = (
+        hi_progress_cls
+        if hi_busy
+        else stitch_progress_cls
+        if stitch_busy
+        else opt_progress_cls
+        if opt_busy
+        else "studio-thumb-progress-idle"
+    )
+    active_progress_pct = (
+        hi_progress_percent
+        if hi_busy
+        else stitch_progress_percent
+        if stitch_busy
+        else opt_progress_percent
+        if opt_busy
+        else 0
+    )
+
     card_id = _thumbnail_card_id(page)
     card_attrs = {"id": card_id}
     if hx_swap_oob:
         card_attrs["hx_swap_oob"] = hx_swap_oob
+
+    menu_id = f"studio-thumb-menu-{page}"
+
     return Div(
         select_btn,
         Div(
@@ -151,35 +174,12 @@ def render_export_thumbnail_card(
             Div(
                 Button(
                     Div(
-                        Span("⬇ Hi", cls="studio-thumb-action-label text-[11px] font-semibold"),
-                        Span(
-                            "",
-                            id=f"studio-thumb-progress-hi-{page}",
-                            cls=f"studio-thumb-progress {hi_progress_cls}",
-                            style=f"--progress:{hi_progress_percent}%;",
-                            aria_hidden="true",
-                        ),
-                        cls="studio-thumb-action-inner",
-                    ),
-                    type="button",
-                    hx_post=highres_url,
-                    hx_include="#studio-export-thumb-page,#studio-export-page-size",
-                    hx_indicator=f"#studio-thumb-progress-hi-{page}",
-                    hx_target=f"#{card_id}",
-                    hx_swap="outerHTML",
-                    disabled=is_busy,
-                    cls="app-btn app-btn-neutral studio-thumb-highres-btn",
-                    data_page=str(page),
-                    title="Riscarica la pagina con fetch diretto max, senza fallback stitching",
-                ),
-                Button(
-                    Div(
-                        Span("🧩 Std", cls="studio-thumb-action-label text-[11px] font-semibold"),
+                        Span("⬇ Scarica", cls="studio-thumb-action-label text-[11px] font-semibold"),
                         Span(
                             "",
                             id=f"studio-thumb-progress-stitch-{page}",
-                            cls=f"studio-thumb-progress {stitch_progress_cls}",
-                            style=f"--progress:{stitch_progress_percent}%;",
+                            cls=f"studio-thumb-progress {active_progress_cls}",
+                            style=f"--progress:{active_progress_pct}%;",
                             aria_hidden="true",
                         ),
                         cls="studio-thumb-action-inner",
@@ -193,33 +193,73 @@ def render_export_thumbnail_card(
                     disabled=is_busy,
                     cls="app-btn app-btn-neutral studio-thumb-stitch-btn",
                     data_page=str(page),
-                    title=(
-                        "Riscarica la pagina usando la strategia standard del volume "
-                        "(es. 3000 -> 1740 -> max, con fallback stitch se serve)"
-                    ),
+                    title="Scarica con strategia standard del volume",
                 ),
-                Button(
-                    Div(
-                        Span("⚙ Opt", cls="studio-thumb-action-label text-[11px] font-semibold"),
-                        Span(
-                            "",
-                            id=f"studio-thumb-progress-opt-{page}",
-                            cls=f"studio-thumb-progress {opt_progress_cls}",
-                            style=f"--progress:{opt_progress_percent}%;",
-                            aria_hidden="true",
-                        ),
-                        cls="studio-thumb-action-inner",
+                Div(
+                    Button(
+                        "⋯",
+                        type="button",
+                        cls=("app-btn app-btn-neutral studio-thumb-menu-toggle text-sm font-bold px-2 py-1"),
+                        disabled=is_busy,
+                        data_menu=menu_id,
+                        aria_expanded="false",
+                        title="Altre azioni",
                     ),
-                    type="button",
-                    hx_post=optimize_url,
-                    hx_include="#studio-export-thumb-page,#studio-export-page-size",
-                    hx_indicator=f"#studio-thumb-progress-opt-{page}",
-                    hx_target=f"#{card_id}",
-                    hx_swap="outerHTML",
-                    disabled=is_busy,
-                    cls="app-btn app-btn-neutral studio-thumb-opt-btn",
-                    data_page=str(page),
-                    title="Ottimizza solo questa pagina",
+                    Div(
+                        Button(
+                            Div(
+                                Span("⬇ Hi-res", cls="text-[11px] font-semibold"),
+                                Span(
+                                    "",
+                                    id=f"studio-thumb-progress-hi-{page}",
+                                    cls=f"studio-thumb-progress {hi_progress_cls}",
+                                    style=f"--progress:{hi_progress_percent}%;",
+                                    aria_hidden="true",
+                                ),
+                                cls="flex items-center justify-between gap-2 w-full",
+                            ),
+                            type="button",
+                            hx_post=highres_url,
+                            hx_include="#studio-export-thumb-page,#studio-export-page-size",
+                            hx_indicator=f"#studio-thumb-progress-hi-{page}",
+                            hx_target=f"#{card_id}",
+                            hx_swap="outerHTML",
+                            disabled=is_busy,
+                            cls="app-btn app-btn-neutral w-full text-left",
+                            data_page=str(page),
+                            title="Fetch diretto max risoluzione, senza fallback stitching",
+                        ),
+                        Button(
+                            Div(
+                                Span("⚙ Ottimizza", cls="text-[11px] font-semibold"),
+                                Span(
+                                    "",
+                                    id=f"studio-thumb-progress-opt-{page}",
+                                    cls=f"studio-thumb-progress {opt_progress_cls}",
+                                    style=f"--progress:{opt_progress_percent}%;",
+                                    aria_hidden="true",
+                                ),
+                                cls="flex items-center justify-between gap-2 w-full",
+                            ),
+                            type="button",
+                            hx_post=optimize_url,
+                            hx_include="#studio-export-thumb-page,#studio-export-page-size",
+                            hx_indicator=f"#studio-thumb-progress-opt-{page}",
+                            hx_target=f"#{card_id}",
+                            hx_swap="outerHTML",
+                            disabled=is_busy,
+                            cls="app-btn app-btn-neutral w-full text-left",
+                            data_page=str(page),
+                            title="Ottimizza solo questa pagina localmente",
+                        ),
+                        id=menu_id,
+                        cls=(
+                            "studio-thumb-dropdown hidden absolute right-0 top-full mt-1 z-20 "
+                            "flex flex-col gap-1 p-1.5 rounded-lg border border-slate-200 dark:border-slate-700 "
+                            "bg-white dark:bg-slate-900 shadow-lg min-w-[8rem]"
+                        ),
+                    ),
+                    cls="relative",
                 ),
                 cls="studio-thumb-action",
             ),

--- a/src/studio_ui/components/studio/export/thumbnails.py
+++ b/src/studio_ui/components/studio/export/thumbnails.py
@@ -356,6 +356,7 @@ def render_export_thumbnails_panel(
             "hx_get": _thumb_page_url(doc_id=doc_id, library=library, thumb_page=prev_page, page_size=page_size),
             "hx_target": "#studio-export-thumbs-slot",
             "hx_swap": "outerHTML",
+            "hx_indicator": "#studio-export-thumbs-loading",
         }
     )
     next_attrs = (
@@ -365,6 +366,7 @@ def render_export_thumbnails_panel(
             "hx_get": _thumb_page_url(doc_id=doc_id, library=library, thumb_page=next_page, page_size=page_size),
             "hx_target": "#studio-export-thumbs-slot",
             "hx_swap": "outerHTML",
+            "hx_indicator": "#studio-export-thumbs-loading",
         }
     )
 
@@ -382,6 +384,14 @@ def render_export_thumbnails_panel(
                 f"Miniature: pagina {thumb_page}/{thumb_page_count} · {total_pages} pagine totali",
                 cls="text-xs text-slate-500 dark:text-slate-400",
             ),
+            Span(
+                "",
+                id="studio-export-thumbs-loading",
+                cls=(
+                    "htmx-indicator inline-block h-4 w-4 border-2 "
+                    "border-slate-300 border-t-cyan-500 rounded-full animate-spin"
+                ),
+            ),
             Div(
                 Select(
                     *[
@@ -398,6 +408,7 @@ def render_export_thumbnails_panel(
                     hx_trigger="change",
                     hx_target="#studio-export-thumbs-slot",
                     hx_swap="outerHTML",
+                    hx_indicator="#studio-export-thumbs-loading",
                     cls="app-field w-32 text-xs",
                 ),
                 Button(

--- a/tests/test_studio_handlers.py
+++ b/tests/test_studio_handlers.py
@@ -697,16 +697,14 @@ def test_studio_export_page_highres_button_has_feedback_hooks(tmp_path):
     finally:
         cm.set_downloads_dir(str(old_downloads))
     rendered = repr(panel)
-    assert "studio-thumb-stitch-btn" in rendered
-    assert "studio-thumb-action-inner" in rendered
-    assert "studio-thumb-action-label" in rendered
+    assert "studio-thumb-download-btn" in rendered
+    assert "studio-thumb-highres-btn" in rendered
+    assert "studio-thumb-opt-btn" in rendered
     assert "studio-thumb-progress-" in rendered
     assert 'hx-target="#studio-thumb-card-1"' in rendered
     assert "/api/studio/export/page_stitch" in rendered
     assert "/api/studio/export/page_highres" in rendered
     assert "/api/studio/export/page_optimize" in rendered
-    assert "studio-thumb-dropdown" in rendered
-    assert "studio-thumb-menu-toggle" in rendered
     assert "studio-thumb-progress htmx-indicator" not in rendered
 
 
@@ -799,8 +797,8 @@ def test_studio_highres_queue_persists_page_job_without_toast(tmp_path, monkeypa
 
         result = studio_handlers.download_highres_export_page(doc_id, library, page=1, thumb_page=1, page_size=24)
         rendered = repr(result)
-        assert "⬇ Hi-res" in rendered
-        assert "⬇ Scarica" in rendered
+        assert 'aria-label="Hi-res"' in rendered
+        assert 'aria-label="Scarica"' in rendered
         assert "studio-thumb-progress-active" in rendered
         assert isinstance(result, list)
         assert 'hx-swap-oob="outerHTML:#studio-export-live-state-poller"' in rendered
@@ -852,7 +850,7 @@ def test_studio_stitch_queue_persists_page_job_without_toast(tmp_path, monkeypat
 
         result = studio_handlers.download_stitch_export_page(doc_id, library, page=1, thumb_page=1, page_size=24)
         rendered = repr(result)
-        assert "⬇ Scarica" in rendered
+        assert 'aria-label="Scarica"' in rendered
         assert "studio-thumb-progress-active" in rendered
         assert isinstance(result, list)
         assert 'hx-swap-oob="outerHTML:#studio-export-live-state-poller"' in rendered
@@ -1027,19 +1025,18 @@ def test_export_thumbs_endpoint_preserves_highres_feedback_on_pagination(tmp_pat
         panel = studio_handlers.get_studio_export_thumbs(doc_id=doc_id, library=library, thumb_page=3, page_size=1)
         rendered = repr(panel)
         assert "Pag. 3" in rendered
-        assert "⬇ Hi-res" in rendered
-        assert "⬇ Scarica" in rendered
-        assert "⚙ Ottimizza" in rendered
+        assert 'aria-label="Hi-res"' in rendered
+        assert 'aria-label="Scarica"' in rendered
+        assert 'aria-label="Ottimizza"' in rendered
         assert "studio-thumb-progress-active" in rendered
         assert "studio-thumb-progress-done" in rendered
-        # Primary button disabled when busy
+        # All buttons disabled when busy
         assert re.search(
-            r"<button[^>]*(?:studio-thumb-stitch-btn[^>]*disabled|disabled[^>]*studio-thumb-stitch-btn)",
+            r"<button[^>]*(?:studio-thumb-download-btn[^>]*disabled|disabled[^>]*studio-thumb-download-btn)",
             rendered,
         )
-        # Dropdown menu-toggle disabled when busy
         assert re.search(
-            r"<button[^>]*(?:studio-thumb-menu-toggle[^>]*disabled|disabled[^>]*studio-thumb-menu-toggle)",
+            r"<button[^>]*(?:studio-thumb-opt-btn[^>]*disabled|disabled[^>]*studio-thumb-opt-btn)",
             rendered,
         )
     finally:
@@ -1433,9 +1430,9 @@ def test_export_thumbs_preserves_running_highres_when_preferred_source_is_highre
         panel = studio_handlers.get_studio_export_thumbs(doc_id=doc_id, library=library, thumb_page=1, page_size=24)
         rendered = repr(panel)
         assert re.search(r'id="studio-thumb-progress-hi-1"[^>]*studio-thumb-progress-active', rendered)
-        # Primary button and menu toggle disabled when hi-res job is active
+        # All buttons disabled when hi-res job is active
         assert re.search(
-            r"<button[^>]*(?:studio-thumb-stitch-btn[^>]*disabled|disabled[^>]*studio-thumb-stitch-btn)",
+            r"<button[^>]*(?:studio-thumb-download-btn[^>]*disabled|disabled[^>]*studio-thumb-download-btn)",
             rendered,
         )
     finally:

--- a/tests/test_studio_handlers.py
+++ b/tests/test_studio_handlers.py
@@ -638,7 +638,7 @@ def test_studio_optimize_scans_updates_metadata_and_feedback(tmp_path):
         result = studio_handlers.optimize_studio_export_scans(doc_id, library, thumb_page=1, page_size=24)
         rendered = repr(result)
         assert "Ottimizzazione completata" in rendered
-        assert "Ultimo run:" in rendered
+        assert "Ultimo:" in rendered
 
         row = vm.get_manuscript(doc_id) or {}
         assert int(row.get("local_optimized") or 0) == 1
@@ -749,7 +749,7 @@ def test_studio_optimize_scans_selected_scope_only_updates_selected_pages(tmp_pa
             optimize_scope="selected",
         )
         rendered = repr(result)
-        assert "Ultimo run: (selezione)" in rendered
+        assert "Ultimo: (sel.)" in rendered
 
         row = vm.get_manuscript(doc_id) or {}
         meta = json.loads(str(row.get("local_optimization_meta_json") or "{}"))

--- a/tests/test_studio_handlers.py
+++ b/tests/test_studio_handlers.py
@@ -697,14 +697,16 @@ def test_studio_export_page_highres_button_has_feedback_hooks(tmp_path):
     finally:
         cm.set_downloads_dir(str(old_downloads))
     rendered = repr(panel)
-    assert "studio-thumb-highres-btn" in rendered
     assert "studio-thumb-stitch-btn" in rendered
     assert "studio-thumb-action-inner" in rendered
     assert "studio-thumb-action-label" in rendered
     assert "studio-thumb-progress-" in rendered
     assert 'hx-target="#studio-thumb-card-1"' in rendered
     assert "/api/studio/export/page_stitch" in rendered
+    assert "/api/studio/export/page_highres" in rendered
     assert "/api/studio/export/page_optimize" in rendered
+    assert "studio-thumb-dropdown" in rendered
+    assert "studio-thumb-menu-toggle" in rendered
     assert "studio-thumb-progress htmx-indicator" not in rendered
 
 
@@ -797,8 +799,8 @@ def test_studio_highres_queue_persists_page_job_without_toast(tmp_path, monkeypa
 
         result = studio_handlers.download_highres_export_page(doc_id, library, page=1, thumb_page=1, page_size=24)
         rendered = repr(result)
-        assert "⬇ Hi" in rendered
-        assert "🧩 St" in rendered
+        assert "⬇ Hi-res" in rendered
+        assert "⬇ Scarica" in rendered
         assert "studio-thumb-progress-active" in rendered
         assert isinstance(result, list)
         assert 'hx-swap-oob="outerHTML:#studio-export-live-state-poller"' in rendered
@@ -850,7 +852,7 @@ def test_studio_stitch_queue_persists_page_job_without_toast(tmp_path, monkeypat
 
         result = studio_handlers.download_stitch_export_page(doc_id, library, page=1, thumb_page=1, page_size=24)
         rendered = repr(result)
-        assert "🧩 St" in rendered
+        assert "⬇ Scarica" in rendered
         assert "studio-thumb-progress-active" in rendered
         assert isinstance(result, list)
         assert 'hx-swap-oob="outerHTML:#studio-export-live-state-poller"' in rendered
@@ -1025,17 +1027,19 @@ def test_export_thumbs_endpoint_preserves_highres_feedback_on_pagination(tmp_pat
         panel = studio_handlers.get_studio_export_thumbs(doc_id=doc_id, library=library, thumb_page=3, page_size=1)
         rendered = repr(panel)
         assert "Pag. 3" in rendered
-        assert "⬇ Hi" in rendered
-        assert "🧩 St" in rendered
-        assert "⚙ Opt" in rendered
+        assert "⬇ Hi-res" in rendered
+        assert "⬇ Scarica" in rendered
+        assert "⚙ Ottimizza" in rendered
         assert "studio-thumb-progress-active" in rendered
         assert "studio-thumb-progress-done" in rendered
+        # Primary button disabled when busy
         assert re.search(
-            r"<button[^>]*(?:studio-thumb-highres-btn[^>]*disabled|disabled[^>]*studio-thumb-highres-btn)",
+            r"<button[^>]*(?:studio-thumb-stitch-btn[^>]*disabled|disabled[^>]*studio-thumb-stitch-btn)",
             rendered,
         )
+        # Dropdown menu-toggle disabled when busy
         assert re.search(
-            r"<button[^>]*(?:studio-thumb-opt-btn[^>]*disabled|disabled[^>]*studio-thumb-opt-btn)",
+            r"<button[^>]*(?:studio-thumb-menu-toggle[^>]*disabled|disabled[^>]*studio-thumb-menu-toggle)",
             rendered,
         )
     finally:
@@ -1429,8 +1433,9 @@ def test_export_thumbs_preserves_running_highres_when_preferred_source_is_highre
         panel = studio_handlers.get_studio_export_thumbs(doc_id=doc_id, library=library, thumb_page=1, page_size=24)
         rendered = repr(panel)
         assert re.search(r'id="studio-thumb-progress-hi-1"[^>]*studio-thumb-progress-active', rendered)
+        # Primary button and menu toggle disabled when hi-res job is active
         assert re.search(
-            r"<button[^>]*(?:studio-thumb-highres-btn[^>]*disabled|disabled[^>]*studio-thumb-highres-btn)",
+            r"<button[^>]*(?:studio-thumb-stitch-btn[^>]*disabled|disabled[^>]*studio-thumb-stitch-btn)",
             rendered,
         )
     finally:


### PR DESCRIPTION
## UX Redesign Export Tab — #142

### Cambiamenti

**1. Toolbar selezione nella tab Immagini** — ☑ Tutte / ☐ Nessuna / Range input sopra la griglia
**2. Loading indicator** — Spinner animato durante cambio pagina thumbnail
**3. Anti doppio-click** — `hx_disabled_elt` su pulsanti bulk ottimizzazione
**4. Card compatte** — 1 pulsante primario (⬇ Scarica) + menu ⋯ (Hi-res, Ottimizza)
**5. Toolbar unificata** — Selezione + azioni bulk in unico pannello, rimossa sezione separata

Closes #142